### PR TITLE
Ch 327: Mid-spring review clean-up

### DIFF
--- a/css/personalize.admin.css
+++ b/css/personalize.admin.css
@@ -92,9 +92,8 @@ input[type="submit"].personalize-add-link:hover {
   display: block;
 }
 
-#personalize-agent-goals-form fieldset.personalize-goal .fieldset-legend {
+#personalize-agent-option-sets-form fieldset.personalize-option-set .fieldset-legend {
   min-height: 1em;
-  position: relative;
 }
 
 #personalize-agent-goals-form fieldset.personalize-goal .fieldset-legend,

--- a/css/personalize.admin.css
+++ b/css/personalize.admin.css
@@ -4,7 +4,7 @@
  */
 
 /**
- * Arrange the goals configuration options in columns.
+ * Goals
  */
 .personalize-goals-wrapper {
   margin-bottom: 1.4em;

--- a/css/personalize.admin.css
+++ b/css/personalize.admin.css
@@ -142,7 +142,7 @@ input[type="submit"].personalize-add-link:hover {
   display: inline-block;
   visibility: hidden;
 }
-.personalize-variation-row input.personalize-variation-winner.personalize-edit {
+.personalize-variation-row div.personalize-variation-winner.personalize-edit input.personalize-variation-winner {
   visibility: visible;
 }
 .personalize-variation-row div.personalize-variation-selected-control,
@@ -153,6 +153,10 @@ input[type="submit"].personalize-add-link:hover {
   background-repeat: no-repeat;
   background-size: contain;
   height: 1.2em;
+}
+
+.personalize-variation-row div.personalize-variation-selected-winner.personalize-edit {
+  background: none;
 }
 
 /* Truncate content variation title */

--- a/css/personalize.admin.css
+++ b/css/personalize.admin.css
@@ -87,22 +87,39 @@ input[type="submit"].personalize-add-link:hover {
 }
 #personalize-agent-option-sets-form fieldset.personalize-option-set,
 #personalize-agent-option-sets-form fieldset.personalize-option-set legend,
-#personalize-agent-option-sets-form fieldset.personalize-option-set .fieldset-legend{
+#personalize-agent-option-sets-form fieldset.personalize-option-set .fieldset-legend {
   width: 100%;
   display: block;
 }
+
+#personalize-agent-goals-form fieldset.personalize-goal .fieldset-legend {
+  min-height: 1em;
+  position: relative;
+}
+
 #personalize-agent-goals-form fieldset.personalize-goal .fieldset-legend,
 #personalize-agent-option-sets-form fieldset.personalize-option-set.collapsed .fieldset-legend {
   background-position: .5em .5em;
+}
+#personalize-agent-option-sets-form fieldset.personalize-option-set legend .fieldset-title {
+  display: inline-block;
+  width: 60%;
+  position: absolute;
+}
+#personalize-agent-option-sets-form fieldset.personalize-option-set legend .fieldset-title div.personalize-admin-enumerated-item {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
 }
 #personalize-agent-option-sets-form fieldset.personalize-option-set .fieldset-legend span.summary {
   display: none;
 }
 #personalize-agent-option-sets-form fieldset.personalize-option-set.collapsed .fieldset-legend span.summary {
-  float: right;
-  margin-right: 2.5em;
   font-weight: normal;
   display: inline-block;
+  position: absolute;
+  right: 1em;
 }
 #personalize-agent-option-sets-form fieldset.personalize-option-set .fieldset-legend span.summary div {
   display: inline;

--- a/css/personalize.theme.css
+++ b/css/personalize.theme.css
@@ -15,7 +15,7 @@
 
 .personalize-admin-content.personalize-collapsed {
   background-color: inherit;
-  border: none;
+  border: 1px solid transparent;
 }
 .personalize-admin-content.personalize-collapsed:hover,
 .personalize-admin-content.personalize-collapsed:active {

--- a/js/personalize.admin.js
+++ b/js/personalize.admin.js
@@ -144,7 +144,7 @@
           hideText = Drupal.t('hide');
         $('.fieldset-wrapper .personalize-option-set-edit-trigger', fieldset).bind('click', function(e) {
           e.preventDefault();
-          $('input.personalize-variation-winner', fieldset).toggleClass('personalize-edit');
+          $('div.personalize-variation-winner', fieldset).toggleClass('personalize-edit');
           var currentText = $(this).text();
           $(this).text(currentText == editText ? hideText : editText);
         });

--- a/js/personalize.admin.js
+++ b/js/personalize.admin.js
@@ -160,4 +160,21 @@
     }
   };
 
+  /**
+   * Scroll to a new goal that has just been added to the admin page.
+   */
+  Drupal.behaviors.personalizeGoalAdded = {
+    attach: function (context, settings) {
+      var $newGoal = $('#personalize-agent-goals-form .personalize-goal-add', context).last();
+      if ($newGoal.length == 0) {
+        return;
+      }
+      var offset = $newGoal.offset();
+      var offsetTop = offset.top + 100; // scroll to just above the new goal
+      $('html, body').animate({
+        scrollTop: offsetTop
+      }, 1000);
+    }
+  };
+
 })(jQuery);

--- a/js/personalize.admin.js
+++ b/js/personalize.admin.js
@@ -13,10 +13,6 @@
    */
   Drupal.personalize.admin.toggleClickHandler = function (event) {
     var $container = [];
-    // Ignore any clicks from the links in the title suffix.
-    if ($(event.target).parents('.personalize-admin-content-title-suffix').length > 0) {
-      return;
-    }
     if ($(event.target).hasClass('personalize-collapsible')) {
       $container = $(event.target);
     } else {
@@ -25,7 +21,13 @@
     if ($container.length == 0) {
       return;
     }
-    Drupal.personalize.admin.togglePersonalizeCollapse($container);
+    // Any clicks from links in the title suffix will expand the container.
+    if ($(event.target).parents('.personalize-admin-content-title-suffix').length > 0) {
+      Drupal.personalize.admin.togglePersonalizeCollapse($container, true);
+    } else {
+      // Otherwise just toggle.
+      Drupal.personalize.admin.togglePersonalizeCollapse($container);
+    }
     event.preventDefault();
     event.stopImmediatePropagation();
   };
@@ -35,11 +37,17 @@
    *
    * @param $container
    *   The jQuery container to toggle.
+   * @param open
+   *   (Optional) boolean indicating if the container should become open.
    */
-  Drupal.personalize.admin.togglePersonalizeCollapse = function ($container) {
+  Drupal.personalize.admin.togglePersonalizeCollapse = function ($container, open) {
     var closedText = Drupal.t('edit'),
       openText = Drupal.t('close'),
       label = $container.hasClass('personalize-collapsed') ? openText : closedText;
+    if (open === true && !$container.hasClass('personalize-collapsed')) {
+      // The container is already open.
+      return;
+    }
     $container.toggleClass('personalize-collapsed');
     $container.children('personalize-collapse-edit').text(label);
     if ($container.hasClass('personalize-collapsed')) {

--- a/js/personalize.admin.js
+++ b/js/personalize.admin.js
@@ -173,7 +173,9 @@
       var offsetTop = offset.top + 100; // scroll to just above the new goal
       $('html, body').animate({
         scrollTop: offsetTop
-      }, 1000);
+      }, 1000, function() {
+        $newGoal.find('select').first().focus();
+      });
     }
   };
 

--- a/modules/personalize_blocks/personalize_blocks.module
+++ b/modules/personalize_blocks/personalize_blocks.module
@@ -309,6 +309,26 @@ function personalize_blocks_personalize_create_new_links() {
 }
 
 /**
+ * Implements hook_personalize_edit_link().
+ */
+function personalize_block_personalize_edit_link($option_set) {
+  if ($option_set->plugin != 'block') {
+    return '';
+  }
+  return "admin/structure/personalize-blocks/manage/{$option_set->osid}/edit";
+}
+
+/**
+ * Implements hook_personalize_edit_link().
+ */
+function personalize_block_personalize_delete_link($option_set) {
+  if ($option_set->plugin != 'block') {
+    return '';
+  }
+  return "admin/structure/personalize-blocks/manage/{$option_set->osid}/delete";
+}
+
+/**
  * Implements hook_personalize_option_values_for_admin().
  */
 function personalize_blocks_personalize_option_values_for_admin($option_set) {

--- a/modules/personalize_blocks/personalize_blocks.module
+++ b/modules/personalize_blocks/personalize_blocks.module
@@ -311,7 +311,7 @@ function personalize_blocks_personalize_create_new_links() {
 /**
  * Implements hook_personalize_edit_link().
  */
-function personalize_block_personalize_edit_link($option_set) {
+function personalize_blocks_personalize_edit_link($option_set) {
   if ($option_set->plugin != 'block') {
     return '';
   }
@@ -321,7 +321,7 @@ function personalize_block_personalize_edit_link($option_set) {
 /**
  * Implements hook_personalize_delete_link().
  */
-function personalize_block_personalize_delete_link($option_set) {
+function personalize_blocks_personalize_delete_link($option_set) {
   if ($option_set->plugin != 'block') {
     return '';
   }

--- a/modules/personalize_blocks/personalize_blocks.module
+++ b/modules/personalize_blocks/personalize_blocks.module
@@ -319,7 +319,7 @@ function personalize_block_personalize_edit_link($option_set) {
 }
 
 /**
- * Implements hook_personalize_edit_link().
+ * Implements hook_personalize_delete_link().
  */
 function personalize_block_personalize_delete_link($option_set) {
   if ($option_set->plugin != 'block') {

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -149,6 +149,26 @@ function personalize_elements_personalize_create_new_links() {
 }
 
 /**
+ * Implements hook_personalize_edit_link().
+ */
+function personalize_elements_personalize_edit_link($option_set) {
+  if ($option_set->plugin != 'elements') {
+    return '';
+  }
+  return "admin/structure/personalize-elements/manage/{$option_set->osid}/edit";
+}
+
+/**
+ * Implements hook_personalize_edit_link().
+ */
+function personalize_elements_personalize_delete_link($option_set) {
+  if ($option_set->plugin != 'elements') {
+    return '';
+  }
+  return "admin/structure/personalize-elements/manage/{$option_set->osid}/delete";
+}
+
+/**
  * Implements hook_personalize_option_values_for_admin().
  */
 function personalize_elements_personalize_option_values_for_admin($option_set) {

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -159,7 +159,7 @@ function personalize_elements_personalize_edit_link($option_set) {
 }
 
 /**
- * Implements hook_personalize_edit_link().
+ * Implements hook_personalize_delete_link().
  */
 function personalize_elements_personalize_delete_link($option_set) {
   if ($option_set->plugin != 'elements') {

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -627,6 +627,32 @@ function personalize_fields_personalize_create_new_links() {
   return $links;
 }
 
+/**
+ * Implements hook_personalize_edit_link().
+ */
+function personalize_fields_personalize_edit_link($option_set) {
+  if ($option_set->plugin != 'fields') {
+    return '';
+  }
+  if ($entity_link = _personalize_fields_get_entity_link_from_option_set($option_set)) {
+    return $entity_link . '/edit';
+  }
+  return '';
+}
+
+/**
+ * Implements hook_personalize_delete_link().
+ */
+function personalize_fields_personalize_delete_link($option_set) {
+  if ($option_set->plugin != 'fields') {
+    return '';
+  }
+  if ($entity_link = _personalize_fields_get_entity_link_from_option_set($option_set)) {
+    return $entity_link . '/delete';
+  }
+  return '';
+}
+
 /*
  * Extract an entity object from a form array.
  *
@@ -694,4 +720,19 @@ function _personalize_fields_get_option_set_for_field($entity_type, $entity_id, 
 function _personalize_fields_get_field_info_from_option_set($osid) {
   $record = db_query("SELECT entity_type, entity_id, field_name FROM {personalize_fields_option_sets} WHERE osid = :osid", array(':osid' => $osid))->fetchAssoc();
   return empty($record) ? array() : $record;
+}
+
+/**
+ * Helper function to get the base entity link for an option set.
+ *
+ * @param stdClass $option_set
+ *   The option set to get the link for.
+ */
+function _personalize_fields_get_entity_link_from_option_set($option_set) {
+  if ($entity_info = _personalize_fields_get_field_info_from_option_set($option_set->osid)) {
+    $entities = entity_load($entity_info['entity_type'], array($entity_info['entity_id']));
+    $entity_link = entity_uri($entity_info['entity_type'], $entities[$entity_info['entity_id']]);
+    return $entity_link['path'];
+  }
+  return '';
 }

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -910,6 +910,8 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
   $option_sets = personalize_option_set_load_by_agent($agent_data->machine_name);
 
   $agent = personalize_agent_load_agent($agent_data->machine_name);
+  $campaign_page = "admin/structure/personalize/manage/{$agent_data->machine_name}/edit";
+
   // Targeting is only supported when a campaign is running.  Also, winners are
   // only shown when the campaign is stopped.
   $is_running = $agent_data->status == PERSONALIZE_STATUS_RUNNING;
@@ -989,7 +991,7 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
     ),
   );
   $form['variations']['primary']['option_sets']['header']['add'] = array(
-    '#markup' => personalize_get_create_new_links_dropbutton("admin/structure/personalize/manage/{$agent_data->machine_name}/edit"),
+    '#markup' => personalize_get_create_new_links_dropbutton($campaign_page),
   );
 
   $section = &$form['variations']['primary']['option_sets'];
@@ -1020,8 +1022,8 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
         'variation_count' => count($option_set->options),
         'report' => $agent instanceof PersonalizeAgentReportInterface ? $agent->renderStatsForOptionSet($option_set, $agent_data->started) : array(),
         'report_link' => $agent instanceof PersonalizeAgentReportInterface ? l(t('report'), "admin/structure/personalize/manage/{$agent_data->machine_name}/report/{$option_set->osid}") : '',
-        'edit_link' => !empty($edit_link) ? l('edit', $edit_link) : '',
-        'delete_link' => !empty($delete_link) ? l('delete', $delete_link, array('query' => array('destination' => current_path()))) : '',
+        'edit_link' => !empty($edit_link) ? l('edit', $edit_link, array('query' => array('destination' => $campaign_page))) : '',
+        'delete_link' => !empty($delete_link) ? l('delete', $delete_link, array('query' => array('destination' => $campaign_page))) : '',
       )),
       '#theme_wrappers' => array('container'),
       '#attributes' => array(

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1101,7 +1101,9 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
       }
       else {
         $classes[] = 'personalize-content-variation-stopped';
-        if (!empty($option_set->winner) && $option_set->winner == $option['option_id']) {
+        // The winner is either previously selected, or the first option.
+        if ((!empty($option_set->winner) && $option_set->winner == $option['option_id']) ||
+          (empty($option_set->winner) && $variant_number == 1)) {
           $is_winner = TRUE;
           $classes[] = 'personalize-content-variation-winner';
         }
@@ -1122,7 +1124,7 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
       );
       $heading = theme('personalize_admin_enumerated_item', array(
         'enum' => t('V@delta', array('@delta' => $variant_number)),
-        'title' => check_plain($option_label),
+        'title' => filter_xss($option_label),
         'title_prefix' => '"',
         'title_suffix' => '"',
         'attributes' => array(

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1000,6 +1000,7 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
   }
 
   foreach ($option_sets as $option_set) {
+    $option_set_plugin = personalize_get_option_set_type($option_set->plugin);
     $section['option_set_' . $option_set->osid] = array(
       '#tree' => TRUE,
       '#type' => 'fieldset',
@@ -1011,12 +1012,16 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
       ),
     );
     // Header information to be shown in the fieldset summary.
+    $edit_link = module_invoke($option_set_plugin['module'], 'personalize_edit_link', $option_set);
+    $delete_link = module_invoke($option_set_plugin['module'], 'personalize_delete_link', $option_set);
     $section['option_set_' . $option_set->osid]['summary'] = array(
       '#type' => 'markup',
       '#markup' => theme('personalize_option_set_header', array(
         'variation_count' => count($option_set->options),
         'report' => $agent instanceof PersonalizeAgentReportInterface ? $agent->renderStatsForOptionSet($option_set, $agent_data->started) : array(),
         'report_link' => $agent instanceof PersonalizeAgentReportInterface ? l(t('report'), "admin/structure/personalize/manage/{$agent_data->machine_name}/report/{$option_set->osid}") : '',
+        'edit_link' => !empty($edit_link) ? l('edit', $edit_link) : '',
+        'delete_link' => !empty($delete_link) ? l('delete', $delete_link, array('query' => array('destination' => current_path()))) : '',
       )),
       '#theme_wrappers' => array('container'),
       '#attributes' => array(
@@ -1090,8 +1095,7 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
     );
 
     $variant_number = 1;
-    $plugin = personalize_get_option_set_type($option_set->plugin);
-    $option_values = module_invoke($plugin['module'], 'personalize_option_values_for_admin', $option_set);
+    $option_values = module_invoke($option_set_plugin['module'], 'personalize_option_values_for_admin', $option_set);
     foreach ($option_set->options as $option) {
       $is_winner = FALSE;
       // Determine container classes based on campaign status and winner.
@@ -1275,7 +1279,7 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
     );
     // Display options to select the executor if supported.
     $executors = personalize_get_executors();
-    $supported_executors = module_invoke($plugin['module'], 'personalize_get_executor_options');
+    $supported_executors = module_invoke($option_set_plugin['module'], 'personalize_get_executor_options');
     if (count($supported_executors) == 1) {
       $section['option_set_' . $option_set->osid]['advanced']['executor'] = array(
         '#type' => 'value',

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -738,7 +738,7 @@ function personalize_agent_goals_form($form, &$form_state, $agent_data) {
   // goals by one.
   $num_goals = count($goals);
   if (isset($form_state['num_goals']) && $form_state['num_goals'] > $num_goals) {
-    $goals[] = array('action' => '', 'value' => 1);
+    $goals[] = array('action' => '', 'value' => 1, 'collapsed' => FALSE, 'classes' => array('personalize-goal-add'));
   }
   $form_state['num_goals'] = count($goals);
 
@@ -826,14 +826,18 @@ function personalize_agent_goals_form($form, &$form_state, $agent_data) {
   );
 
   foreach ($goals as $delta => $goal) {
+    $goal_fieldset_classes = array('personalize-admin-collapsed-content', 'personalize-goal');
+    if (isset($goal['classes']) && is_array($goal['classes'])) {
+      $goal_fieldset_classes = array_merge($goal_fieldset_classes, $goal['classes']);
+    }
     $section['goals'][$delta] = array(
       '#type' => 'fieldset',
       '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#collapsed' => isset($goal['collapsed']) ? $goal['collapsed'] : TRUE,
       '#title' => $goal_labels[$delta],
       '#tree' => TRUE,
       '#attributes' => array(
-        'class' => array('personalize-admin-collapsed-content', 'personalize-goal'),
+        'class' => $goal_fieldset_classes,
         'id' => "personalize-goal-$delta"
       )
     );

--- a/personalize.api.php
+++ b/personalize.api.php
@@ -230,6 +230,36 @@ function hook_personalize_create_new_links() {
 }
 
 /**
+ * Returns link to edit the option set.
+ *
+ * This hook is implemented by modules that provide an Option Set type, and
+ * returns the path to edit an option set.
+ *
+ * @param stdClass $option_set
+ *   The option set to edit.
+ *
+ * @return string
+ *   The path to the edit the option set.
+ */
+function hook_personalize_edit_link($option_set) {
+}
+
+/**
+ * Returns link to delete the option set.
+ *
+ * This hook is implemented by modules that provide an Option Set type, and
+ * returns the path to delete an option set.
+ *
+ * @param stdClass $option_set
+ *   The option set to delete.
+ *
+ * @return string
+ *   The path to the delete the option set.
+ */
+function hook_personalize_delete_link($option_set) {
+}
+
+/**
  * Returns option values to show in the admin UI.
  *
  * This hook must be implemented by modules providing Option Set type

--- a/theme/personalize.theme.inc
+++ b/theme/personalize.theme.inc
@@ -160,6 +160,8 @@ function theme_personalize_option_set_report($variables) {
  *   - variation_count: the number of variations within the option set.
  *   - report: an array of reporting statistics for this option set.
  *   - report_link: the link to the report for this option set.
+ *   - edit_link: the link to edit the option set.
+ *   - delete_link: the link to delete the option set.
  * @return string
  *   The themed output.
  */
@@ -171,7 +173,13 @@ function theme_personalize_option_set_header($variables) {
     $output .= theme('personalize_option_set_report', array('report' => $variables['report']));
   }
   if (!empty($variables['report_link'])) {
-    $output .= '<span class="personalize-option-header-report-link">' . $variables['report_link'] . '</span>';
+    $output .= '<span class="personalize-option-header-item">' . $variables['report_link'] . '</span>';
+  }
+  if (!empty($variables['edit_link'])) {
+    $output .= '<span class="personalize-option-header-item">' . $variables['edit_link'] . '</span>';
+  }
+  if (!empty($variables['delete_link'])) {
+    $output .= '<span class="personalize-option-header-item">' . $variables['delete_link'] . '</span>';
   }
   return $output;
 }


### PR DESCRIPTION
- Add edit/delete links for content option sets.
- personalize admin collapsible containers need a border in the non-active state to prevent "hopping"
- percentage input currently updates upon focus-out
- fallback/winner should be pre-selected as the first option
- add a goal should make new goal option clearer
