### PR TITLE
CH-322: Show confirmation prompt to user on campaign edit form

### DIFF
--- a/js/personalize.admin.js
+++ b/js/personalize.admin.js
@@ -90,6 +90,41 @@
   };
 
   /**
+   * Campaign edit form submission handling.
+   *
+   * Adds a confirmation prompt to the user when they are about to make changes
+   * to a running campaign that will result in pausing the campaign.
+   */
+  Drupal.behaviors.personalizeCampaignEditFormHandling = {
+    attach: function (context, settings) {
+      // Add a handler to form submits that trigger campaign status changes.
+      $('#personalize-agent-form input[type="submit"], #personalize-agent-option-sets-form input[type="submit"]').not('.form-reset, input[name="toggle_submit"]').once().each(function() {;
+        var currentCampaign = Drupal.settings.personalize.activeCampaign;
+        if (typeof currentCampaign === 'undefined') {
+          return;
+        }
+        // Overwrite beforeSubmit for each submit button (no cancel).
+        Drupal.ajax[this.id].options.beforeSubmit = function(form_values, $element, options) {
+          var campaign = Drupal.settings.personalize.campaigns[currentCampaign];
+          if (typeof(campaign) === 'undefined') {
+            return;
+          }
+          if (Drupal.settings.personalize.status && Drupal.settings.personalize.status[campaign.status]) {
+            var currentStatus = Drupal.settings.personalize.status[campaign.status];
+            if (currentStatus === Drupal.t('Running')) {
+              if (confirm(Drupal.t('Making these changes will pause the currently running campaign.  Are you sure you want to continue?'))) {
+                return true;
+              } else {
+                return false;
+              }
+            }
+          }
+        }
+      });
+    }
+  }
+
+  /**
    * Add personalize admin content header sections.
    *
    * This is content that should appear inline with the admin content title.

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -540,6 +540,20 @@ function personalize_agent_form_ajax_submit($form, $form_state) {
     $form_div_id = 'personalize-agent-form';
   }
 
+  // Update the current agent status.
+  if (!empty($agent_data)) {
+    $settings = array(
+      'personalize' => array(
+        'campaigns' => array(
+          $agent_data->machine_name => array(
+            'status' => $agent_data->status,
+          ),
+        ),
+      ),
+    );
+    $commands[] = ajax_command_settings($settings, TRUE);
+  }
+
   // Show status messages relative to the personalize page.
   $commands[] = ajax_command_replace('#personalize-agent-page-messages', '<div id="personalize-agent-page-messages">' . theme('status_messages') . '</div>');
 

--- a/personalize.module
+++ b/personalize.module
@@ -283,6 +283,9 @@ function personalize_page_build(&$page) {
     }
   }
   if (user_access('manage personalized content')) {
+    // Provide the status constants
+    $settings['status'] = personalize_get_agent_status_map();
+
     // We need to provide information about all configured campaigns
     // and goals for the control UI.
     $actions = visitor_actions_get_actions();
@@ -296,6 +299,7 @@ function personalize_page_build(&$page) {
       $settings['campaigns'][$agent->machine_name] = array(
         'name' => $agent->machine_name,
         'label' => filter_xss($agent->label),
+        'status' => $agent->status,
         'links' => array(
           'view' => '/admin/structure/personalize/manage/' . $agent->machine_name,
           'edit' => '/admin/structure/personalize/manage/' . $agent->machine_name . '/edit',


### PR DESCRIPTION
Show only when performing actions that will pause an actively running campaign.

Went with simplest UI approach here, we can always swap that out if we want fancier.
