### PR TITLE
CH-372: support tying multiple option sets together as one conceptual decision

### DIFF
--- a/includes/personalize.classes.inc
+++ b/includes/personalize.classes.inc
@@ -123,9 +123,12 @@ interface PersonalizeAgentInterface {
   /**
    * Checks whether the agent is ready to run.
    *
-   * @return boolean
+   * @return array
+   *   A non-empty array indicates that the agent did not pass the check. Each
+   *   element in the array should be a string providing information about why
+   *   the agent failed the check.
    */
-  public function verify();
+  public function errors();
 }
 
 interface PersonalizeAgentReportInterface {
@@ -288,8 +291,8 @@ abstract class PersonalizeAgentBase implements PersonalizeAgentInterface, Person
   /**
    * Implements PersonalizeAgentInterface::verify().
    */
-  public function verify() {
-    return TRUE;
+  public function errors() {
+    return array();
   }
 
   /**

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -89,7 +89,7 @@ function personalize_elements_page_build(&$page) {
       unset($option_sets[$osid]);
       continue;
     }
-    $js_id = $js_id = _personalize_get_nonnumeric_osid($option_set->osid);
+    $js_id = $js_id = personalize_stringify_osid($option_set->osid);
     $elements[$js_id] = array(
       'selector' => $option_set->data['personalize_elements_selector'],
       'variation_type' => $option_set->data['personalize_elements_type'],

--- a/modules/personalize_elements/tests/personalize_elements.test
+++ b/modules/personalize_elements/tests/personalize_elements.test
@@ -185,7 +185,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $settings = $this->drupalGetSettings();
     $personalize_elements_settings = $settings['personalize_elements'];
     $this->assertEqual(PERSONALIZE_ELEMENTS_CONTROL_OPTION_ID, $personalize_elements_settings['controlOptionName']);
-    $js_id = $js_id = _personalize_get_nonnumeric_osid($option_set->osid);
+    $js_id = $js_id = personalize_stringify_osid($option_set->osid);
     $expected = array(
       $js_id => array(
         'selector' => $selector,

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1265,12 +1265,12 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data) {
     // @todo Once we want to provide support for using the same decision name across
     //   option sets we'll need to allow setting the decision name here, but it must
     //   be a machine name.
-    /*$form['option_sets']['option_set_' . $option_set->osid]['decision_name'] = array(
+    $section['option_set_' . $option_set->osid]['advanced']['decision_name'] = array(
       '#type' => 'textfield',
       '#title' => 'Decision Name',
-      '#description' => 'By default, this decision will be named after the Option Set id. You can use this if you want to make one conceptual decision across multiple fields such as a special offer which manifests in different places on the site',
+      '#description' => 'By default, this decision will be named after the content variation ID. You can use this if you want to make one conceptual decision across multiple content variations such as a special offer which manifests in different places on the site',
       '#default_value' => isset($option_set->decision_name) ? $option_set->decision_name : '',
-    );*/
+    );
     $section['option_set_' . $option_set->osid]['advanced']['stateful'] = array(
       '#type' => 'checkbox',
       '#title' => t('Shareable'),
@@ -1603,7 +1603,9 @@ function personalize_agent_option_sets_form_submit($form, &$form_state) {
       if ($values['winner']) {
         $option_set->winner = $values['winner'];
       }
-
+      if (isset($values['advanced']['decision_name'])) {
+        $option_set->decision_name = personalize_generate_machine_name($values['advanced']['decision_name']);
+      }
       if (!isset($values['options'])) {
         personalize_option_set_save($option_set);
         continue;

--- a/personalize.module
+++ b/personalize.module
@@ -254,9 +254,9 @@ function personalize_page_build(&$page) {
   if (isset($_GET[PERSONALIZE_PRESELECTION_PARAM])) {
     $preselected = explode(',', $_GET[PERSONALIZE_PRESELECTION_PARAM]);
     foreach ($preselected as $option_str) {
-      list($osid, $selection) = explode('--', trim($option_str));
+      list($osid_str, $selection) = explode('--', trim($option_str));
       // Make sure this is a valid option set.
-      if ($option_set = personalize_get_option_set_for_decision($osid)) {
+      if ($osid = personalize_resolve_stringified_osid($osid_str) && $option_set = personalize_option_set_load($osid)) {
         foreach ($option_set->options as $option) {
           if ($option['option_id'] === $selection) {
             $settings['preselected'][$osid] = $option['option_id'];
@@ -977,14 +977,37 @@ function personalize_get_option_label_for_decision_and_choice($decision_name, $o
  *   The name of the decision the option belongs to.
  *
  * @return
- *   The option set class or FALSE if none can be found.
+ *   The option set object or FALSE if none can be found.
  */
 function personalize_get_option_set_for_decision($decision_name) {
-  if (preg_match("/^osid\-(\d+)$/", $decision_name, $matches) !== FALSE) {
-    $osid = $matches[1];
+  $option_sets = personalize_option_set_load_multiple(array(), array('decision_name' => $decision_name));
+  if (!empty($option_sets)) {
+    return reset($option_sets);
+  }
+  elseif ($osid = personalize_resolve_stringified_osid($decision_name)) {
     return personalize_option_set_load($osid);
   }
-  return FALSE;
+  return NULL;
+}
+
+/**
+ * Resolves an Option Set ID in the form 'osid-123' to just the numeric ID.
+ *
+ * @param string $osid
+ *   An Option Set ID in the form 'osid-n' where n is the numeric ID.
+ *
+ * @return int
+ *   The numeric part of the ID or NULL if there is none.
+ */
+function personalize_resolve_stringified_osid($osid) {
+  if (is_numeric($osid)) {
+    return (int) $osid;
+  }
+  $prefix = preg_quote(PERSONALIZE_OPTION_SET_PREFIX);
+  if (preg_match("/^$prefix(\d+)$/", $osid, $matches) !== FALSE) {
+    return $matches[1];
+  }
+  return NULL;
 }
 
 /**
@@ -1768,7 +1791,7 @@ function personalize_get_decision_name_for_option_set($option_set) {
     return $option_set->decision_name;
   }
   // Default to a name based on the osid.
-  return _personalize_get_nonnumeric_osid($option_set->osid);
+  return personalize_stringify_osid($option_set->osid);
 }
 
 /**
@@ -2295,7 +2318,7 @@ function _personalize_generate_option_index($index) {
 function _personalize_convert_option_set_to_js_setting($option_set) {
   // We never want to use numeric keys in the JS so convert it to a
   // string using the prefix if it is numeric.
-  $js_id = _personalize_get_nonnumeric_osid($option_set->osid);
+  $js_id = personalize_stringify_osid($option_set->osid);
   $os_array = (array) $option_set;
   $os_array['osid'] = $js_id;
   $option_names = array();
@@ -2349,6 +2372,6 @@ function personalize_form_element_add_states($state, &$element) {
  * @param $osid
  * @return string
  */
-function _personalize_get_nonnumeric_osid($osid) {
+function personalize_stringify_osid($osid) {
   return is_numeric($osid) ? PERSONALIZE_OPTION_SET_PREFIX . $osid : $osid;
 }

--- a/personalize.module
+++ b/personalize.module
@@ -692,6 +692,15 @@ function personalize_agent_set_status($agent_name, $status) {
   return TRUE;
 }
 
+function personalize_verify_campaign($agent_name) {
+  // Do a check before setting the status to running.
+  $agent_instance = personalize_agent_load_agent($agent_name);
+  if (!$agent_instance->verify()) {
+    drupal_set_message(t('There is a problem with this agent and it cannot be run at this time.'), 'error');
+    return FALSE;
+  }
+}
+
 /**
  * Returns the current status of the specified agent.
  *
@@ -1355,7 +1364,7 @@ function personalize_agent_machine_name_exists($machine_name) {
 }
 
 /**
- * Generates a machine-readable agent name based on the passed in name.
+ * Generates a machine-readable name based on the passed in name.
  *
  * @param $name
  *   The human-readable name of the agent.

--- a/personalize.module
+++ b/personalize.module
@@ -668,8 +668,8 @@ function personalize_agent_set_status($agent_name, $status) {
   if ($status == PERSONALIZE_STATUS_RUNNING) {
     // Do a check before setting the status to running.
     $agent_instance = personalize_agent_load_agent($agent_name);
-    if (!$agent_instance->verify()) {
-      drupal_set_message(t('There is a problem with this agent and it cannot be run at this time.'), 'error');
+    if (!personalize_verify_agent($agent_name)) {
+      drupal_set_message(t('There is a problem with this campaign and it cannot be run at this time.'), 'error');
       return FALSE;
     }
     // If we're setting a campaign to the running status for the first time,
@@ -692,13 +692,58 @@ function personalize_agent_set_status($agent_name, $status) {
   return TRUE;
 }
 
-function personalize_verify_campaign($agent_name) {
-  // Do a check before setting the status to running.
+/**
+ * Runs various checks to make sure the agent is good to go.
+ *
+ * @param string $agent_name
+ *   THe name of the agent.
+ *
+ * @return bool
+ *   Whether or not the agent passed all the checks.
+ */
+function personalize_verify_agent($agent_name) {
+  // Check the option sets to make sure they are all valid.
+  $option_sets = personalize_option_set_load_by_agent($agent_name);
+  $decisions = array();
+  foreach ($option_sets as $osid => $option_set) {
+    if (isset($decisions[$option_set->decision_name])) {
+      if (count($decisions[$option_set->decision_name]) != count($option_set->options)) {
+        // Option Sets using the same decision name must have the same number of options.
+        drupal_set_message(t('The Option Set @title has @count options but uses the decision @decision which requires @count2 options', array(
+          '@title' => $option_set->label,
+          '@count' => count($option_set->options),
+          '@decision' => $option_set->decision_name,
+          '@count2' => count($decisions[$option_set->decision_name]))), 'error');
+        return FALSE;
+      }
+      // The option IDs of the Option Sets must also be the same.
+      foreach ($option_set->options as $option) {
+        if (!in_array($option['option_id'], $decisions[$option_set->decision_name])) {
+          drupal_set_message(t('The Option Set @title uses the decision @decision but has different option IDs. Option IDs cannot be changed so you will need to delete the options and recreate them.', array(
+            '@title' => $option_set->label,
+            '@decision' => $option_set->decision_name)), 'error');
+          return FALSE;
+        }
+      }
+    }
+    else {
+      // Store this decision name to check subsequent Option Sets against.
+      $decisions[$option_set->decision_name] = array();
+      foreach ($option_set->options as $option) {
+        $decisions[$option_set->decision_name][] = $option['option_id'];
+      }
+    }
+  }
+  // Now allow the agent to run a check.
   $agent_instance = personalize_agent_load_agent($agent_name);
-  if (!$agent_instance->verify()) {
-    drupal_set_message(t('There is a problem with this agent and it cannot be run at this time.'), 'error');
+  $errors = $agent_instance->errors();
+  if (!empty($errors)) {
+    foreach ($errors as $error) {
+      drupal_set_message($error, 'error');
+    }
     return FALSE;
   }
+  return TRUE;
 }
 
 /**

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1296,7 +1296,7 @@ class PersonalizeTest extends DrupalWebTestCase {
    * @see personalize_generate_machine_name()
    * @see testSaveAgent()
    */
-  protected function createTestAgent($data = array(), $cleanQueue = TRUE) {
+  protected function createTestAgent($data = array()) {
     $data += array(
       'name' => $this->randomName(),
     );
@@ -1314,5 +1314,24 @@ class PersonalizeTest extends DrupalWebTestCase {
     $this->assertTrue($agent instanceof PersonalizeTestAgent);
 
     return $agent;
+  }
+
+  protected function createOptionSet($index, $option_set) {
+    if (!isset($option_set['label'])) {
+      $option_set['label'] = 'Option Set ' . ($index + 1);
+    }
+
+    foreach ($option_set['options'] as $i => &$option) {
+      if (!isset($option['option_id'])) {
+        $option['option_id'] = personalize_generate_option_id($i);
+      }
+      if (!isset($option['option_label'])) {
+        $option['option_label'] = personalize_generate_option_label($i);
+      }
+    }
+
+    $option_set = (object) $option_set;
+    personalize_option_set_save($option_set);
+    return $option_set;
   }
 }

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -925,7 +925,7 @@ class PersonalizeTest extends DrupalWebTestCase {
     $html_id_first_agent = "personalize-toggle-status-{$first_agent_machine_name}-form";
     $this->drupalPost('admin/structure/personalize', array(), t('Start'), array(), array(), $html_id_first_agent);
     // No error should have been set.
-    $this->assertNoText('There is a problem with this agent and it cannot be run at this time');
+    $this->assertNoText('There is a problem with this campaign and it cannot be run at this time');
     // The agent's status should now be "running".
     $this->assertEqual(PERSONALIZE_STATUS_RUNNING, personalize_agent_get_status($first_agent_machine_name));
     $this->resetAll();
@@ -954,7 +954,7 @@ class PersonalizeTest extends DrupalWebTestCase {
     $html_id_second_agent = "personalize-toggle-status-{$second_agent_machine_name}-form";
     $this->drupalPost('admin/structure/personalize', array(), t('Start'), array(), array(), $html_id_second_agent);
     // Its verify() method will have returned false so a message should have been set.
-    $this->assertText('There is a problem with this agent and it cannot be run at this time');
+    $this->assertText('There is a problem with this campaign and it cannot be run at this time');
     // The agent's status should still be "not started"
     $this->assertEqual(PERSONALIZE_STATUS_NOT_STARTED, personalize_agent_get_status($second_agent_machine_name));
   }

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1201,6 +1201,7 @@ class PersonalizeTest extends DrupalWebTestCase {
     $admin_user = $this->drupalCreateUser(array('manage personalized content', 'access administration pages', 'administer blocks'));
     $this->drupalLogin($admin_user);
     $agent = $this->createTestAgent(array('agent_type' => 'test_agent'));
+    $agent_name = $agent->getMachineName();
     // Create two block-based option sets.
     $option_sets = array();
     $block_ids = array('comment_delta_recent', 'system_delta_powered-by', 'user_delta_online', 'user_delta_new');
@@ -1210,7 +1211,7 @@ class PersonalizeTest extends DrupalWebTestCase {
         array('bid' => array_shift($block_ids)),
         array('bid' => array_shift($block_ids)),
       );
-      $option_sets[] = $this->createOptionSet($i, array('plugin' => 'block', 'agent' => $agent->getMachineName(), 'options' => $options, 'data' => array('block_title' => $this->randomName())));
+      $option_sets[] = $this->createOptionSet($i, array('plugin' => 'block', 'agent' => $agent_name, 'options' => $options, 'data' => array('block_title' => $this->randomName())));
     }
     // We're going to make the second option set have the same decision name as the
     // first, which will tie them together conceptually as one decision.
@@ -1218,7 +1219,7 @@ class PersonalizeTest extends DrupalWebTestCase {
     $edit = array(
       "option_sets[option_set_{$option_sets[1]->osid}][advanced][decision_name]" => $decision_name
     );
-    $this->drupalPost("admin/structure/personalize/manage/{$agent->getMachineName()}/edit", $edit, $this->getButton('option'));
+    $this->drupalPost("admin/structure/personalize/manage/{$agent_name}/edit", $edit, $this->getButton('option'));
     $second_os = personalize_option_set_load($option_sets[1]->osid, TRUE);
     $this->assertEqual(PERSONALIZE_OPTION_SET_PREFIX . $option_sets[0]->osid, $second_os->decision_name);
 
@@ -1241,7 +1242,7 @@ class PersonalizeTest extends DrupalWebTestCase {
       "option_sets[option_set_{$option_sets[0]->osid}][advanced][decision_name]" => $new_name,
       "option_sets[option_set_{$option_sets[1]->osid}][advanced][decision_name]" => $new_name
     );
-    $this->drupalPost("admin/structure/personalize/manage/{$agent->getMachineName()}/edit", $edit, $this->getButton('option'));
+    $this->drupalPost("admin/structure/personalize/manage/{$agent_name}/edit", $edit, $this->getButton('option'));
     $this->drupalGet('');
     $settings = $this->drupalGetSettings();
     $option_set_settings = $settings['personalize']['option_sets'];
@@ -1249,6 +1250,47 @@ class PersonalizeTest extends DrupalWebTestCase {
     $this->assertEqual('some-non-machine-readable-name', $option_set_settings['osid-1']['decision_name']);
     // Assert that both blocks have the same decision name.
     $this->assertEqual($option_set_settings['osid-1']['decision_name'], $option_set_settings['osid-2']['decision_name']);
+    $set_status = personalize_agent_set_status($agent_name, PERSONALIZE_STATUS_RUNNING);
+    // Confirm that there was no problem settings this agent's status to Running.
+    $this->assertTrue($set_status);
+
+    // Now change one of the option sets so that the two have different numbers of options.
+    $os = personalize_option_set_load(2, TRUE);
+    $os->options[] = array(
+      'option_id' => 'option-C',
+      'option_label' => 'Option C',
+      'bid' => 'system_delta_powered-by'
+    );
+    personalize_option_set_save($os);
+
+    $status = personalize_agent_get_status($agent_name);
+    $this->assertEqual(PERSONALIZE_STATUS_PAUSED, $status);
+
+    // Go to the campaign page and try to set the status to running. We should get an
+    // error about the number of options.
+    $this->drupalPost("admin/structure/personalize/manage/{$agent_name}/edit", array(), t('Resume'));
+    $this->assertText("The Option Set {$second_os->label} has 3 options but uses the decision some-non-machine-readable-name which requires 2 options");
+    // Confirm that the agent is still paused.
+    $status = personalize_agent_get_status($agent_name);
+    $this->assertEqual(PERSONALIZE_STATUS_PAUSED, $status);
+
+    // Now add a third option to the other option set but give it a different
+    // option ID.
+    $os = personalize_option_set_load(1, TRUE);
+    $os->options[] = array(
+      'option_id' => 'my-new-option',
+      'option_label' => 'Option C',
+      'bid' => 'user_delta_online'
+    );
+    personalize_option_set_save($os);
+
+    // Go to the campaign page and try to set the status to running. We should get an
+    // error about the option IDs not being the same.
+    $this->drupalPost("admin/structure/personalize/manage/{$agent_name}/edit", array(), t('Resume'));
+    $this->assertText("The Option Set {$second_os->label} uses the decision some-non-machine-readable-name but has different option IDs. Option IDs cannot be changed so you will need to delete the options and recreate them.");
+    // Confirm that the agent is still paused.
+    $status = personalize_agent_get_status($agent_name);
+    $this->assertEqual(PERSONALIZE_STATUS_PAUSED, $status);
   }
 
   /**

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1197,6 +1197,60 @@ class PersonalizeTest extends DrupalWebTestCase {
     $this->assertTrue($settings['personalize']['cacheVisitorContext']);
   }
 
+  public function testOptionSetDecisionName() {
+    $admin_user = $this->drupalCreateUser(array('manage personalized content', 'access administration pages', 'administer blocks'));
+    $this->drupalLogin($admin_user);
+    $agent = $this->createTestAgent(array('agent_type' => 'test_agent'));
+    // Create two block-based option sets.
+    $option_sets = array();
+    $block_ids = array('comment_delta_recent', 'system_delta_powered-by', 'user_delta_online', 'user_delta_new');
+    for ($i = 0; $i < 2; $i++) {
+      // Each option set will have 2 options.
+      $options = array(
+        array('bid' => array_shift($block_ids)),
+        array('bid' => array_shift($block_ids)),
+      );
+      $option_sets[] = $this->createOptionSet($i, array('plugin' => 'block', 'agent' => $agent->getMachineName(), 'options' => $options, 'data' => array('block_title' => $this->randomName())));
+    }
+    // We're going to make the second option set have the same decision name as the
+    // first, which will tie them together conceptually as one decision.
+    $decision_name = personalize_get_decision_name_for_option_set($option_sets[0]);
+    $edit = array(
+      "option_sets[option_set_{$option_sets[1]->osid}][advanced][decision_name]" => $decision_name
+    );
+    $this->drupalPost("admin/structure/personalize/manage/{$agent->getMachineName()}/edit", $edit, $this->getButton('option'));
+    $second_os = personalize_option_set_load($option_sets[1]->osid, TRUE);
+    $this->assertEqual(PERSONALIZE_OPTION_SET_PREFIX . $option_sets[0]->osid, $second_os->decision_name);
+
+    // Now let's place the blocks in a region and make sure the correct js settings
+    // show up when they're rendered.
+    $edit = array();
+    $edit['blocks[personalize_blocks_1][region]'] = 'sidebar_first';
+    $edit['blocks[personalize_blocks_2][region]'] = 'sidebar_first';
+    $this->drupalPost('admin/structure/block', $edit, t('Save blocks'));
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $option_set_settings = $settings['personalize']['option_sets'];
+    // Assert that both blocks have the same decision name.
+    $this->assertEqual($option_set_settings['osid-1']['decision_name'], $option_set_settings['osid-2']['decision_name']);
+
+    // Change both decision names to something else. The string should be converted
+    // to a machine name.
+    $new_name = 'Some non-machine-readable %name';
+    $edit = array(
+      "option_sets[option_set_{$option_sets[0]->osid}][advanced][decision_name]" => $new_name,
+      "option_sets[option_set_{$option_sets[1]->osid}][advanced][decision_name]" => $new_name
+    );
+    $this->drupalPost("admin/structure/personalize/manage/{$agent->getMachineName()}/edit", $edit, $this->getButton('option'));
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $option_set_settings = $settings['personalize']['option_sets'];
+    // Assert that the name was sanitized.
+    $this->assertEqual('some-non-machine-readable-name', $option_set_settings['osid-1']['decision_name']);
+    // Assert that both blocks have the same decision name.
+    $this->assertEqual($option_set_settings['osid-1']['decision_name'], $option_set_settings['osid-2']['decision_name']);
+  }
+
   /**
    * Asserts that a wrapper div for the specified Option Set has been output.
    *

--- a/tests/personalize_test_extra_agent/plugins/agent_types/PersonalizeTestExtraAgent.inc
+++ b/tests/personalize_test_extra_agent/plugins/agent_types/PersonalizeTestExtraAgent.inc
@@ -47,7 +47,9 @@ class PersonalizeTestExtraAgent extends PersonalizeAgentBase implements Personal
     return PersonalizeExplicitTargetingInterface::EXPLICIT_TARGETING_MULTIPLE_BOTH;
   }
 
-  public function verify() {
-    return FALSE;
+  public function errors() {
+    return array(
+      'Agent is not valid.'
+    );
   }
 }

--- a/theme/personalize.theme.inc
+++ b/theme/personalize.theme.inc
@@ -30,7 +30,7 @@ function theme_personalize_options_wrapper($variables) {
   }
 
   $option_set = $variables['element']['#personalize_option_set'];
-  $js_id = _personalize_get_nonnumeric_osid($option_set->osid);
+  $js_id = personalize_stringify_osid($option_set->osid);
   $prefix = '<div class="' . PERSONALIZE_OPTION_SET_CLASS . '" id="personalize-' . $js_id . '">';
   if (isset($variables['element']['#first_option'])) {
     $prefix .= '<noscript>' . drupal_render($variables['element']['#first_option']) . '</noscript>';
@@ -58,7 +58,7 @@ function theme_personalize_options_wrapper($variables) {
  */
 function theme_personalize_options_callback_wrapper($variables) {
   $option_set = $variables['element']['#personalize_option_set'];
-  $js_id = _personalize_get_nonnumeric_osid($option_set->osid);
+  $js_id = personalize_stringify_osid($option_set->osid);
   $rendered = '<div class="' . PERSONALIZE_OPTION_SET_CLASS . '" id="personalize-' . $js_id . '"></div>';
   $rendered .= '<noscript>' . drupal_render($variables['element']['#first_option']) . '</noscript>';
   return $rendered;


### PR DESCRIPTION
Includes renaming some functions to resolve the confusion around decision name vs. stringified option set name. Also adds a change to how we verify campaigns before allowing them to run.
