### PR TITLE
Can't pass by reference with call_user_func_array, but the alternative r...

### DIFF
--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1500,7 +1500,7 @@ function personalize_agent_form_validate($form, &$form_state) {
   ctools_include('plugins');
   if ($class = ctools_plugin_load_class('personalize', 'agent_type', $agent_type, 'handler')) {
     // Call the validation callback for the agent type.
-    call_user_func_array(array($class, 'optionsFormValidate'), array($form, $form_state));
+    $class::optionsFormValidate($form, $form_state);
   }
 }
 

--- a/personalize.info
+++ b/personalize.info
@@ -1,12 +1,12 @@
 name = Personalize
 description = The Personalize module serves as an API for controlling personalization of content on pages based on the user's context.
 configure = admin/config/content/personalize
+package = Personalization
+core = 7.x
+php = 5.3
 
 dependencies[] = ctools
 dependencies[] = visitor_actions
 
 files[] = includes/personalize.classes.inc
 files[] = tests/personalize.test
-
-package = Personalization
-core = 7.x


### PR DESCRIPTION
Required a change in personalize module that introduces a requirement on PHP 5.3 because in 5.2 you can't use a variable class name when calling a static method on that class. The normal workaround is to use call_user_func_array() instead, but you can't pass arguments by reference when using call_user_func_array(). The only other alternative would be to not have the validation callbacks be class methods but just regular functions. Damned if I'm going to let PHP 5.2 (which was EOL'd 3 years ago) dictate the architecture here though.
