### PR TITLE
Ch 421: Allow friendly names for all content variations

### DIFF
--- a/modules/personalize_blocks/js/personalize_blocks.admin.js
+++ b/modules/personalize_blocks/js/personalize_blocks.admin.js
@@ -1,0 +1,35 @@
+(function ($) {
+
+  Drupal.personalizeBlocks = Drupal.personalizeBlocks || {};
+  /**
+   * Handles setting the initial value for option labels as blocks are selected.
+   *
+   * This is to allow a default option label that has meaning and rather than
+   * forcing the user to adjust this for each block selected.
+   */
+  Drupal.behaviors.personalizeBlockOptionLabel = {
+    attach: function(context, settings) {
+      Drupal.personalizeBlocks.changedOptionLabels = Drupal.personalizeBlocks.changedOptionLabels || [];
+
+      // Update the appropriate option label when a block is selected so long
+      // as the user has not yet changed the label.
+      $('#personalize-blocks-form .personalize-blocks-add-block-select', context).once().change(function(e) {
+        var $optionLabel = $(this).parents('tr').find('.personalize-blocks-add-option-label');
+        if (Drupal.personalizeBlocks.changedOptionLabels.indexOf($optionLabel.attr('id')) >= 0) {
+          // The user has already changed the label.
+          return;
+        }
+        // Text is displayed in the format "Friendly (module:machine)".
+        var blockRe = /\s\(([a-zA-Z]|\d)+:([a-zA-Z]|\d)+\)$/;
+        $optionLabel.val($(this).find('option:selected').text().replace(blockRe, ''));
+      });
+
+      // Once the user updates the option label it should no longer be changed
+      // automatically.
+      $('#personalize-blocks-form .personalize-blocks-add-option-label', context).once().change(function(e) {
+        Drupal.personalizeBlocks.changedOptionLabels.push($(this).attr('id'));
+      });
+    }
+  }
+
+})(jQuery);

--- a/modules/personalize_blocks/js/personalize_blocks.admin.js
+++ b/modules/personalize_blocks/js/personalize_blocks.admin.js
@@ -13,7 +13,7 @@
 
       // Update the appropriate option label when a block is selected so long
       // as the user has not yet changed the label.
-      $('#personalize-blocks-form .personalize-blocks-add-block-select', context).once().change(function(e) {
+      $('.personalize-blocks-add-block-select', context).once().change(function(e) {
         var $optionLabel = $(this).parents('tr').find('.personalize-blocks-add-option-label');
         if (Drupal.personalizeBlocks.changedOptionLabels.indexOf($optionLabel.attr('id')) >= 0) {
           // The user has already changed the label.
@@ -26,7 +26,7 @@
 
       // Once the user updates the option label it should no longer be changed
       // automatically.
-      $('#personalize-blocks-form .personalize-blocks-add-option-label', context).once().change(function(e) {
+      $('.personalize-blocks-add-option-label', context).once().change(function(e) {
         Drupal.personalizeBlocks.changedOptionLabels.push($(this).attr('id'));
       });
     }

--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -294,7 +294,7 @@ function theme_personalize_blocks_admin_form_blocks($variables) {
   $draggable = isset($blocks['#draggable']) && $blocks['#draggable'];
   $rows = array();
   $header = array(
-    t('Option'),
+    t('Variation label'),
   );
   if ($draggable) {
     drupal_add_tabledrag('personalize-blocks-table', 'order', 'sibling', 'personalized-blocks-weight');

--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -84,6 +84,8 @@ function personalize_blocks_form($form, &$form_state, $formtype, $pblock = NULL)
     $form += personalize_get_agent_selection_form($current_agent);
   }
 
+  $form['#attached']['js'][] = drupal_get_path('module', 'personalize_blocks') . '/js/personalize_blocks.admin.js';
+
   $form['title'] = array(
     '#title' => t('Title'),
     '#description' => t('This will be the administrative title of the block.'),
@@ -206,12 +208,6 @@ function _personalize_blocks_form(array $block, $pblock) {
     '#size' => '10',
     '#default_value' => isset($block['option_label']) ? $block['option_label'] : '',
   );
-  if (isset($block['option_id'])) {
-    $form['option_id'] = array(
-      '#type' => 'value',
-      '#value' => $block['option_id'],
-    );
-  }
 
   $form['weight'] = array(
     '#type' => 'weight',
@@ -272,6 +268,17 @@ function _personalize_blocks_form(array $block, $pblock) {
     ),
     '#limit_validation_errors' => array(),
   );
+
+  if (isset($block['option_id'])) {
+    $form['option_id'] = array(
+      '#type' => 'value',
+      '#value' => $block['option_id'],
+    );
+  }
+  else {
+    $form['option_label']['#attributes']['class'][] = 'personalize-blocks-add-option-label';
+    $form['bid']['#attributes']['class'][] = 'personalize-blocks-add-block-select';
+  }
 
   return $form;
 }

--- a/modules/personalize_blocks/personalize_blocks.module
+++ b/modules/personalize_blocks/personalize_blocks.module
@@ -329,25 +329,6 @@ function personalize_blocks_personalize_delete_link($option_set) {
 }
 
 /**
- * Implements hook_personalize_option_values_for_admin().
- */
-function personalize_blocks_personalize_option_values_for_admin($option_set) {
-  if ($option_set->plugin != 'block') {
-    return array();
-  }
-  $option_values = array();
-  foreach($option_set->options as &$option) {
-    list($module, $delta) = PersonalizedBlock::extractBlockId($option['bid']);
-    $block = block_load($module, $delta);
-    if (empty($block->title)) {
-      $custom_block = block_custom_block_get($delta);
-    }
-    $option_values[$option['option_id']] = empty($block->title) ? $custom_block['info'] : $block->title;
-  }
-  return $option_values;
-}
-
-/**
  * Implements hook_personalize_get_executor_options().
  */
 function personalize_blocks_personalize_get_executor_options() {

--- a/modules/personalize_elements/js/personalize_elements.admin.js
+++ b/modules/personalize_elements/js/personalize_elements.admin.js
@@ -1,0 +1,38 @@
+(function ($) {
+
+  Drupal.personalizeElements = Drupal.personalizeElements || {};
+  /**
+   * Handles setting the initial value for option labels as element content is entered.
+   *
+   * This is to allow a default option label that has meaning and rather than
+   * forcing the user to adjust this for each content variation.
+   */
+  Drupal.behaviors.personalizeElementsOptionLabel = {
+    attach: function(context, settings) {
+      var maxOptionLabelLength = 20;
+
+      Drupal.personalizeElements.changedOptionLabels = Drupal.personalizeElements.changedOptionLabels || [];
+
+      // Update the appropriate option label when a block is selected so long
+      // as the user has not yet changed the label.
+      $('.personalize-elements-add-content', context).keyup(function(e) {
+        var $optionLabel = $(this).parents('.personalize-elements-option-content-element').prev('.personalize-elements-option-label-element').find('.personalize-elements-add-option-label');
+        if (Drupal.personalizeElements.changedOptionLabels.indexOf($optionLabel.attr('id')) >= 0) {
+          // The user has already changed the label.
+          return;
+        }
+        // Limit the text used as the label.
+        var newLabel = $(this).val();
+        var truncateLength = Math.min(maxOptionLabelLength, newLabel.length);
+        $optionLabel.val(newLabel.substring(0, truncateLength));
+      });
+
+      // Once the user updates the option label it should no longer be changed
+      // automatically.
+      $('#personalize-elements-form .personalize-elements-add-option-label', context).change(function(e) {
+        Drupal.personalizeElements.changedOptionLabels.push($(this).attr('id'));
+      });
+    }
+  }
+
+})(jQuery);

--- a/modules/personalize_elements/js/personalize_elements.admin.js
+++ b/modules/personalize_elements/js/personalize_elements.admin.js
@@ -13,7 +13,7 @@
 
       Drupal.personalizeElements.changedOptionLabels = Drupal.personalizeElements.changedOptionLabels || [];
 
-      // Update the appropriate option label when a block is selected so long
+      // Update the appropriate option label when an element is selected so long
       // as the user has not yet changed the label.
       $('.personalize-elements-add-content', context).keyup(function(e) {
         var $optionLabel = $(this).parents('.personalize-elements-option-content-element').prev('.personalize-elements-option-label-element').find('.personalize-elements-add-option-label');

--- a/modules/personalize_elements/js/personalize_elements.admin.js
+++ b/modules/personalize_elements/js/personalize_elements.admin.js
@@ -22,7 +22,7 @@
           return;
         }
         // Limit the text used as the label.
-        var newLabel = $(this).val();
+        var newLabel = $(this).val().replace(/<(?:.|\n)*?>/gm, '');
         var truncateLength = Math.min(maxOptionLabelLength, newLabel.length);
         $optionLabel.val(newLabel.substring(0, truncateLength));
       });

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -185,7 +185,7 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
       '#prefix' => '<div class="personalize-elements-option-label-element">',
       '#suffix' => '</div>',
       '#type' => 'textfield',
-      '#title' => t('Option label'),
+      '#title' => t('Variation label'),
       '#size' => 20,
       '#default_value' => !empty($option['option_label']) ? $option['option_label'] : '',
     );

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -187,7 +187,7 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
       '#type' => 'textfield',
       '#title' => t('Variation label'),
       '#size' => 20,
-      '#default_value' => !empty($option['option_label']) ? $option['option_label'] : '',
+      '#default_value' => !empty($option['option_label']) ? check_plain($option['option_label']) : '',
     );
     $option_form['personalize_elements_content'] = array(
       '#prefix' => '<div class="personalize-elements-option-content-element">',

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -60,12 +60,16 @@ function personalize_elements_list() {
  * Form for creating a new action.
  */
 function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option_set = NULL) {
+  $path = drupal_get_path('module', 'personalize_elements');
   $form = array(
     '#attached' => array(
       'css' => array(
-        drupal_get_path('module', 'personalize_elements') . '/css/personalize_elements.admin.css'
-       )
-    )
+        $path . '/css/personalize_elements.admin.css',
+       ),
+      'js' => array(
+        $path . '/js/personalize_elements.admin.js',
+      ),
+    ),
   );
 
   if (!$option_set) {
@@ -193,6 +197,10 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
       '#title' => t('Content'),
       '#default_value' => !empty($option['personalize_elements_content']) ? $option['personalize_elements_content'] : '',
     );
+    if (empty($option_set->osid)) {
+      $option_form['option_label']['#attributes']['class'][] = 'personalize-elements-add-option-label';
+      $option_form['personalize_elements_content']['#attributes']['class'][] = 'personalize-elements-add-content';
+    }
     $form['options_wrapper']['options'][$delta] = $option_form;
   }
   $form['options_wrapper']['options'][0]['option_label']['#states'] =

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -169,25 +169,6 @@ function personalize_elements_personalize_delete_link($option_set) {
 }
 
 /**
- * Implements hook_personalize_option_values_for_admin().
- */
-function personalize_elements_personalize_option_values_for_admin($option_set) {
-  if ($option_set->plugin != 'elements') {
-    return array();
-  }
-  $option_values = array();
-  foreach($option_set->options as &$option) {
-    if ($option['option_id'] == PERSONALIZE_ELEMENTS_CONTROL_OPTION_ID) {
-      $option_values[$option['option_id']] = PERSONALIZE_ELEMENTS_CONTROL_OPTION_LABEL;
-    }
-    else {
-      $option_values[$option['option_id']] = truncate_utf8($option['personalize_elements_content'], 100, FALSE, TRUE);
-    }
-  }
-  return $option_values;
-}
-
-/**
  * Implements hook_personalize_elements_variation_types().
  */
 function personalize_elements_personalize_elements_variation_types() {

--- a/modules/personalize_fields/js/personalize_fields.admin.js
+++ b/modules/personalize_fields/js/personalize_fields.admin.js
@@ -1,0 +1,50 @@
+(function ($) {
+
+  Drupal.personalizeFields = Drupal.personalizeFields || {};
+  /**
+   * Handles setting the initial value for option labels as fields are added.
+   *
+   * This is to allow a default option label that has meaning and rather than
+   * forcing the user to adjust this for each field added.
+   */
+  Drupal.behaviors.personalizeFieldsOptionLabel = {
+    attach: function(context, settings) {
+      Drupal.personalizeFields.changedOptionLabels = Drupal.personalizeFields.changedOptionLabels || [];
+
+      var maxOptionLabelLength = 20;
+
+      // Update the appropriate option label when a block is selected so long
+      // as the user has not yet changed the label.
+      $('.personalize-fields-add-option-label', context).each(function(e) {
+        var $label = $(this);
+        if ($(this).parents('.image-widget-data').length > 0) {
+          // Set the option label to the uploaded filename.
+          $(this).parents('.image-widget-data').find('input.form-file').change(function(e) {
+            if (Drupal.personalizeFields.changedOptionLabels.indexOf($label.attr('id')) >= 0) {
+              return;
+            }
+            // Only set the filename itself (not the whole path).
+            $label.val($(this).val().replace(/^.*(\\|\/|\:)/, ''));
+          });
+        } else {
+          // Set the option label to the field text.
+          $(this).parent().prev().find('input.form-text').keyup(function(e) {
+            if (Drupal.personalizeFields.changedOptionLabels.indexOf($label.attr('id')) >= 0) {
+              return;
+            }
+            var newLabel = $(this).val();
+            var truncateLength = Math.min(maxOptionLabelLength, newLabel.length);
+            $label.val(newLabel.substring(0, truncateLength));
+          });
+        }
+      });
+
+      // Once the user updates the option label it should no longer be changed
+      // automatically.
+      $('.personalize-fields-add-option-label', context).change(function(e) {
+        Drupal.personalizeFields.changedOptionLabels.push($(this).attr('id'));
+      });
+    }
+  }
+
+})(jQuery);

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -150,52 +150,45 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
   // Load the default agent if one is already set.
   $current_agent = NULL;
   foreach ($personalized_fields as $key => $field) {
+    // If there were fields submitted (due to remove or add another) then make
+    // sure we only include those existing option sets that remain.
+    if (isset($form_state['values'][$key][$languages[$key]])) {
+      foreach($form_state['values'][$key][$languages[$key]] as $delta => $submitted) {
+        if (isset($submitted['personalize_fields_option_id'])) {
+          $limit_option_ids[] = $submitted['personalize_fields_option_id'];
+        }
+      }
+    }
+    $field_counter = 0;
+
     // Load the Option Sets if we have an entity id and entity.
     if ($entity_id && ($option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key))) {
       $current_agent = $option_set->agent;
-      // Renumber the options for use in comparison below.
-      $options = array_values($option_set->options);
-    }
 
-    // Add a field for the option set label to each multivalue field.
+      // Add the content variation field data for each option.
+      foreach ($option_set->options as $option) {
+        if (isset($limit_option_ids) && !in_array($option['option_id'], $limit_option_ids)) {
+          // This option has been removed from the form.
+          continue;
+        }
+        $form[$key][$languages[$key]][$field_counter] += _personalize_fields_form(
+          $field_counter,
+          $form[$key][$languages[$key]][$field_counter],
+          "{$key}[{$languages[$key]}][{$field_counter}]",
+          isset($form_state['values'][$key][$languages[$key]][$field_counter]) ? $form_state['values'][$key][$languages[$key]][$field_counter] : NULL,
+          $option
+        );
+        $field_counter++;
+      }
+    }
+    // Now add any "Add another" content variation field data.
     $num = isset($form[$key][$languages[$key]]['#max_delta']) ? $form[$key][$languages[$key]]['#max_delta'] : $form[$key][$languages[$key]]['#file_upload_delta'];
-    for ($i=0; $i <= $num; $i++) {
-      $is_new = FALSE;
-      // Option label previously set.
-      if (isset($form_state['values'][$key][$languages[$key]][$i]['personalize_fields_option_label'])) {
-        $default_label = $form_state['values'][$key][$languages[$key]][$i]['personalize_fields_option_label'];
-      } else if (!empty($options[$i]['option_label'])) {
-        $default_label = $options[$i]['option_label'];
-      }
-      // Use filename as default for image multivalue fields.
-      else if (!empty($form[$key][$languages[$key]][$i]['#default_value']['fid']) && (int) $form[$key][$languages[$key]][$i]['#default_value']['fid'] > 0) {
-        $file = file_load($form[$key][$languages[$key]][$i]['#default_value']['fid']);
-        $default_label = $file->filename;
-      }
-      // Use text as default for text multivalue fields.
-      else if (!empty($form[$key][$languages[$key]][$i]['#default_value']) && is_string($form[$key][$languages[$key]][$i]['#default_value'])) {
-        $default_label = $form[$key][$languages[$key]][$i]['#default_value'];
-      }
-      else {
-        // Just generate a generic option label.
-        $default_label = personalize_generate_option_label($i);
-        // This also means that there is no content yet for this option.
-        $is_new = TRUE;
-      }
-      // Add the actual label field.
-      $form[$key][$languages[$key]][$i]['personalize_fields_option_label'] = array(
-        '#type' => 'text',
-        '#title' => t('Administration label'),
-        '#default_value' => $default_label,
-        '#theme' => 'textfield',
-        '#autocomplete_path' => '',
-        '#theme_wrappers' => array('form_element'),
-        '#weight' => isset($form[$key][$field_lang][$i]['value']) ? $form[$key][$field_lang][$i]['value']['#weight'] + 10 : $form[$key][$field_lang][$i]['#weight'] + 10,
-        '#attributes' => array(
-          'class' => $is_new ? array('personalize-fields-admin-option-label', 'personalize-fields-add-option-label') : array('personalize-fields-admin-option-label'),
-        ),
-        '#name' => "{$key}[{$languages[$key]}][{$i}][personalize_fields_option_label]",
-        '#input' => TRUE,
+    for ($field_counter; $field_counter <= $num; $field_counter++) {
+      $form[$key][$languages[$key]][$field_counter] += _personalize_fields_form(
+        $field_counter,
+        $form[$key][$languages[$key]][$field_counter],
+        "{$key}[{$languages[$key]}][{$field_counter}]",
+        isset($form_state['values'][$key][$languages[$key]][$field_counter]) ? $form_state['values'][$key][$languages[$key]][$field_counter] : NULL
       );
     }
   }
@@ -221,6 +214,83 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     '#type' => 'value',
     '#value' => $personalized_fields,
   );
+}
+
+/**
+ * Generate the personalize field option form API array for an option.
+ *
+ * @param int $delta
+ *   The index for this option in the form.
+ * @param array $field
+ *   The personalized field within the form data.
+ * @param string $form_state_parents
+ *   The flattened parent reference for the current personalized field.
+ * @param array $values
+ *   (optional) The submitted values for this content variation set.
+ * @param array $option
+ *   (optional) The option that is represented in the form.
+ * @return
+ *   The form render array for the content variation data.
+ */
+function _personalize_fields_form($delta, $field, $form_state_parents, $values = NULL, $option = NULL) {
+  // Add a field for the option set label to each multivalue field.
+  $form = array();
+  $is_empty = FALSE;
+
+  // Add the option id if this is an existing option.
+  if (!empty($option)) {
+    $form['personalize_fields_option_id'] = array(
+      '#type' => 'value',
+      '#value' => $option['option_id'],
+    );
+  }
+
+  // Option label previously set.
+  if (!empty($values['personalize_fields_option_label'])) {
+    $default_label = $values['personalize_fields_option_label'];
+  }
+  // Option label on existing content variation option.
+  else if (!empty($option['option_label'])) {
+    $default_label = $option['option_label'];
+  }
+  // Use filename as default for image multivalue fields.
+  else if (!empty($field['#default_value']['fid']) && (int) $field['#default_value']['fid'] > 0) {
+    $file = file_load($field['#default_value']['fid']);
+    $default_label = $file->filename;
+  }
+  // Use text as default for text multivalue fields.
+  else if (!empty($field['value']['#default_value']) && is_string($field['value']['#default_value'])) {
+    $default_label = $field['value']['#default_value'];
+  }
+  // Just generate a generic option label.
+  else {
+    $default_label = personalize_generate_option_label($delta);
+    // This also means that there is no content yet for this option.
+    $is_empty = TRUE;
+  }
+  $label_weight = 10;
+  if (isset($field['value']['#weight'])) {
+    $label_weight = $field['value']['#weight'] + 10;
+  }
+  else if (isset($field['#weight'])) {
+    $label_weight = $field['#weight'] + 10;
+  }
+  // Add the actual label field.
+  $form['personalize_fields_option_label'] = array(
+    '#type' => 'text',
+    '#title' => t('Content variation label'),
+    '#default_value' => $default_label,
+    '#theme' => 'textfield',
+    '#autocomplete_path' => '',
+    '#theme_wrappers' => array('form_element'),
+    '#weight' => $label_weight,
+    '#attributes' => array(
+      'class' => $is_empty ? array('personalize-fields-admin-option-label', 'personalize-fields-add-option-label') : array('personalize-fields-admin-option-label'),
+    ),
+    '#name' => "{$form_state_parents}[personalize_fields_option_label]",
+    '#input' => TRUE,
+  );
+  return $form;
 }
 
 /**
@@ -328,26 +398,40 @@ function personalize_fields_form_submit($form, &$form_state) {
       $option_set->plugin = 'fields';
       $option_set->agent = $agent_name;
 
+      $option_hash = array();
+      foreach ($option_set->options as $delta => $option) {
+        $option_hash[$option['option_id']] = $delta;
+      }
+      $keep_option_deltas = array();
       // Now update the options based on what the user passed in
       foreach ($values[$key][LANGUAGE_NONE] as $delta => $option) {
+        $option_set_delta = isset($option['personalize_fields_option_id']) && in_array($option['personalize_fields_option_id'], $option_hash) ? $option_hash[$option['personalize_fields_option_id']] : FALSE;
+        // Regenerate the option label if it was emptied.
+        $option_label = !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : personalize_generate_option_label($delta);
         if (!empty($option['value']) || (isset($option['fid']) && (int) $option['fid'] > 0)) {
-          $option_label = !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : personalize_generate_option_label($delta);
           // Update an existing option.
-          if (isset($option_set->options[$delta])) {
-            $option_set->options[$delta]['option_label'] = $option_label;
+          if (($option_set_delta) !== FALSE) {
+            $option_set->options[$option_set_delta]['option_label'] = $option_label;
+            $keep_option_deltas[] = $option_set_delta;
           }
+          // Adding a new option
           else {
-            // Adding a new option
-            $option_set->options[$delta]['option_label'] = $option_label;
+            $option_set->options[]['option_label'] = $option_label;
           }
         }
+        // This option is being deleted.
         else {
-          if (isset($option['value']) || isset($option['fid'])) {
-            // This option is being deleted.
-            unset($option_set->options[$delta]);
+          if ($option_set_delta !== FALSE && (isset($option['value']) || isset($option['fid']))) {
+            unset($option_set->options[$option_set_delta]);
           }
         }
       }
+      foreach ($option_set->options as $delta => $option) {
+        if (!empty($option['option_id']) && !in_array($delta, $keep_option_deltas)) {
+          unset($option_set->options[$delta]);
+        }
+      }
+
       // If the entity already has an ID then the options will be saved on
       // hook_entity_update.  Otherwise we add the info to the entity so that
       // it will be processed on hook_entity_insert.
@@ -492,15 +576,26 @@ function personalize_fields_entity_presave($entity, $type) {
   $entities = entity_load($type, array($entity_id), array(), TRUE);
   $current = $entities[$entity_id];
   foreach($entity->option_sets as $field_name => $option_set) {
-    // Re-index the options so that we can compare.
-    $current_options = array_values($current->option_sets[$field_name]->options);
-    $entity_options = array_values($option_set->options);
-    if (count($entity_options) != count($current_options)) {
+    $current_options = $current->option_sets[$field_name]->options;
+    if (count($option_set->options) != count($current->option_sets[$field_name]->options)) {
       $updates[$field_name] = TRUE;
       continue;
     }
-    foreach($entity_options as $delta => $option) {
-      if ($current_options[$delta]['option_label'] != $option['option_label']) {
+    // Get a hash of the option id/delta for comparison.
+    $current_hash = array();
+    foreach($current_options as $delta => $option) {
+      $current_hash[$option['option_id']] = $delta;
+    }
+    // Check for updates.
+    foreach($option_set->options as $delta => $option) {
+      if (!empty($option['option_id']) && in_array($option['option_id'], $current_hash)) {
+        $current_option_label = $current_options[$current_hash[$option['option_id']]]['option_label'];
+        if ($current_option_label != $option['option_label']) {
+          $updates[$field_name] = TRUE;
+        }
+      }
+      else {
+        // New option.
         $updates[$field_name] = TRUE;
       }
     }

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -145,6 +145,8 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     return;
   }
 
+  $form['#attached']['js'][] = drupal_get_path('module', 'personalize_fields') . '/js/personalize_fields.admin.js';
+
   // Load the default agent if one is already set.
   $current_agent = NULL;
   foreach ($personalized_fields as $key => $field) {
@@ -155,13 +157,17 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     // Add a field for the option set label to each multivalue field.
     $num = isset($form[$key][$languages[$key]]['#max_delta']) ? $form[$key][$languages[$key]]['#max_delta'] : $form[$key][$languages[$key]]['#file_upload_delta'];
     for ($i=0; $i <= $num; $i++) {
+      $is_new = FALSE;
       // Option label previously set.
-      if (!empty($option_set->options[$i]['option_label'])) {
+      if (isset($form_state['values'][$key][$languages[$key]][$i]['personalize_fields_option_label'])) {
+        $default_label = $form_state['values'][$key][$languages[$key]][$i]['personalize_fields_option_label'];
+      } else if (!empty($option_set->options[$i]['option_label'])) {
         $default_label = $option_set->options[$i]['option_label'];
       }
       // Use filename as default for image multivalue fields.
       else if (!empty($form[$key][$languages[$key]][$i]['#default_value']['fid']) && (int) $form[$key][$languages[$key]][$i]['#default_value']['fid'] > 0) {
-        $default_label = $form[$key][$languages[$key]][$i]['#default_value']['filename'];
+        $file = file_load($form[$key][$languages[$key]][$i]['#default_value']['fid']);
+        $default_label = $file->filename;
       }
       // Use text as default for text multivalue fields.
       else if (!empty($form[$key][$languages[$key]][$i]['#default_value']) && is_string($form[$key][$languages[$key]][$i]['#default_value'])) {
@@ -170,6 +176,8 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
       else {
         // Just generate a generic option label.
         $default_label = personalize_generate_option_label($i);
+        // This also means that there is no content yet for this option.
+        $is_new = TRUE;
       }
       // Add the actual label field.
       $form[$key][$languages[$key]][$i]['personalize_fields_option_label'] = array(
@@ -181,7 +189,7 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
         '#theme_wrappers' => array('form_element'),
         '#weight' => isset($form[$key][$field_lang][$i]['value']) ? $form[$key][$field_lang][$i]['value']['#weight'] + 10 : $form[$key][$field_lang][$i]['#weight'] + 10,
         '#attributes' => array(
-          'class' => array('personalize-fields-admin-option-label'),
+          'class' => $is_new ? array('personalize-fields-admin-option-label', 'personalize-fields-add-option-label') : array('personalize-fields-admin-option-label'),
         ),
         '#name' => "{$key}[{$languages[$key]}][{$i}][personalize_fields_option_label]",
         '#input' => TRUE,

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -153,16 +153,25 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
       $current_agent = $option_set->agent;
     }
     // Add a field for the option set label to each multivalue field.
-    for ($i=0; $i <= $form[$key][$languages[$key]]['#max_delta']; $i++) {
+    $num = isset($form[$key][$languages[$key]]['#max_delta']) ? $form[$key][$languages[$key]]['#max_delta'] : $form[$key][$languages[$key]]['#file_upload_delta'];
+    for ($i=0; $i <= $num; $i++) {
+      // Option label previously set.
       if (!empty($option_set->options[$i]['option_label'])) {
         $default_label = $option_set->options[$i]['option_label'];
       }
-      else if (!empty($form[$key][$languages[$key]][$i]['#default_value'])) {
+      // Use filename as default for image multivalue fields.
+      else if (!empty($form[$key][$languages[$key]][$i]['#default_value']['fid']) && (int) $form[$key][$languages[$key]][$i]['#default_value']['fid'] > 0) {
+        $default_label = $form[$key][$languages[$key]][$i]['#default_value']['filename'];
+      }
+      // Use text as default for text multivalue fields.
+      else if (!empty($form[$key][$languages[$key]][$i]['#default_value']) && is_string($form[$key][$languages[$key]][$i]['#default_value'])) {
         $default_label = $form[$key][$languages[$key]][$i]['#default_value'];
       }
       else {
+        // Just generate a generic option label.
         $default_label = personalize_generate_option_label($i);
       }
+      // Add the actual label field.
       $form[$key][$languages[$key]][$i]['personalize_fields_option_label'] = array(
         '#type' => 'text',
         '#title' => t('Administration label'),
@@ -170,7 +179,7 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
         '#theme' => 'textfield',
         '#autocomplete_path' => '',
         '#theme_wrappers' => array('form_element'),
-        '#weight' => $form[$key][$field_lang][$i]['value']['#weight'] + 10,
+        '#weight' => isset($form[$key][$field_lang][$i]['value']) ? $form[$key][$field_lang][$i]['value']['#weight'] + 10 : $form[$key][$field_lang][$i]['#weight'] + 10,
         '#attributes' => array(
           'class' => array('personalize-fields-admin-option-label'),
         ),
@@ -251,7 +260,7 @@ function personalize_fields_form_validate($form, &$form_state) {
 
 function personalize_fields_form_submit($form, &$form_state) {
   $values = $form_state['values'];
-  
+
   if (isset($values['agent_select']) && isset($values['personalized_fields'])) {
 
     // Extract information about the entity from the form.
@@ -298,6 +307,10 @@ function personalize_fields_form_submit($form, &$form_state) {
       $current_deltas = array();
       foreach($values[$key][LANGUAGE_NONE] as $delta => $option) {
         if (!empty($option['value'])) {
+          $current_deltas[] = $delta;
+          $option_set->options[$delta]['option_label'] =  !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : _personalize_generate_option_index($delta);
+        }
+        else if (isset($option['fid']) && (int) $option['fid'] > 0) {
           $current_deltas[] = $delta;
           $option_set->options[$delta]['option_label'] =  !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : _personalize_generate_option_index($delta);
         }

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -278,7 +278,7 @@ function _personalize_fields_form($delta, $field, $form_state_parents, $values =
   // Add the actual label field.
   $form['personalize_fields_option_label'] = array(
     '#type' => 'text',
-    '#title' => t('Content variation label'),
+    '#title' => t('Variation label'),
     '#default_value' => $default_label,
     '#theme' => 'textfield',
     '#autocomplete_path' => '',

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -153,7 +153,10 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     // Load the Option Sets if we have an entity id and entity.
     if ($entity_id && ($option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key))) {
       $current_agent = $option_set->agent;
+      // Renumber the options for use in comparison below.
+      $options = array_values($option_set->options);
     }
+
     // Add a field for the option set label to each multivalue field.
     $num = isset($form[$key][$languages[$key]]['#max_delta']) ? $form[$key][$languages[$key]]['#max_delta'] : $form[$key][$languages[$key]]['#file_upload_delta'];
     for ($i=0; $i <= $num; $i++) {
@@ -161,8 +164,8 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
       // Option label previously set.
       if (isset($form_state['values'][$key][$languages[$key]][$i]['personalize_fields_option_label'])) {
         $default_label = $form_state['values'][$key][$languages[$key]][$i]['personalize_fields_option_label'];
-      } else if (!empty($option_set->options[$i]['option_label'])) {
-        $default_label = $option_set->options[$i]['option_label'];
+      } else if (!empty($options[$i]['option_label'])) {
+        $default_label = $options[$i]['option_label'];
       }
       // Use filename as default for image multivalue fields.
       else if (!empty($form[$key][$languages[$key]][$i]['#default_value']['fid']) && (int) $form[$key][$languages[$key]][$i]['#default_value']['fid'] > 0) {
@@ -295,6 +298,7 @@ function personalize_fields_form_submit($form, &$form_state) {
       if (!$loaded_option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key)) {
         $option_set = new stdClass();
         $option_set->is_new = TRUE;
+        $option_set->options = array();
       } else {
         // Changes are made to the option set to reflect the user's changes and
         // compared against the option set for the entity in entity hooks.
@@ -305,10 +309,14 @@ function personalize_fields_form_submit($form, &$form_state) {
         // PHP clone only makes a shallow copy and as a result the options
         // are passed by reference.  Therefore we need to do our own deep copy.
         $option_set = new StdClass();
+        $options = array();
         foreach($loaded_option_set as $prop => $value) {
           if (is_array($value)) {
             $option_set->{$prop} = array();
             foreach($value as $i => $array_value) {
+              if ($prop === 'options') {
+                $options[$array_value['option_id']] = $i;
+              }
               $option_set->{$prop}[] = $array_value;
             }
           }
@@ -319,23 +327,27 @@ function personalize_fields_form_submit($form, &$form_state) {
       }
       $option_set->plugin = 'fields';
       $option_set->agent = $agent_name;
-      $current_deltas = array();
-      foreach($values[$key][LANGUAGE_NONE] as $delta => $option) {
-        if (!empty($option['value'])) {
-          $current_deltas[] = $delta;
-          $option_set->options[$delta]['option_label'] =  !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : _personalize_generate_option_index($delta);
-        }
-        else if (isset($option['fid']) && (int) $option['fid'] > 0) {
-          $current_deltas[] = $delta;
-          $option_set->options[$delta]['option_label'] =  !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : _personalize_generate_option_index($delta);
-        }
-      }
-      // Remove any options that are no longer included.
-      $remove = array_diff_key($option_set->options, $current_deltas);
-      foreach($remove as $delta => $value) {
-        unset($option_set->options[$delta]);
-      }
 
+      // Now update the options based on what the user passed in
+      foreach ($values[$key][LANGUAGE_NONE] as $delta => $option) {
+        if (!empty($option['value']) || (isset($option['fid']) && (int) $option['fid'] > 0)) {
+          $option_label = !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : personalize_generate_option_label($delta);
+          // Update an existing option.
+          if (isset($option_set->options[$delta])) {
+            $option_set->options[$delta]['option_label'] = $option_label;
+          }
+          else {
+            // Adding a new option
+            $option_set->options[$delta]['option_label'] = $option_label;
+          }
+        }
+        else {
+          if (isset($option['value']) || isset($option['fid'])) {
+            // This option is being deleted.
+            unset($option_set->options[$delta]);
+          }
+        }
+      }
       // If the entity already has an ID then the options will be saved on
       // hook_entity_update.  Otherwise we add the info to the entity so that
       // it will be processed on hook_entity_insert.
@@ -480,15 +492,15 @@ function personalize_fields_entity_presave($entity, $type) {
   $entities = entity_load($type, array($entity_id), array(), TRUE);
   $current = $entities[$entity_id];
   foreach($entity->option_sets as $field_name => $option_set) {
-    if (count($option_set->options) != count($current->option_sets[$field_name]->options)) {
+    // Re-index the options so that we can compare.
+    $current_options = array_values($current->option_sets[$field_name]->options);
+    $entity_options = array_values($option_set->options);
+    if (count($entity_options) != count($current_options)) {
       $updates[$field_name] = TRUE;
       continue;
     }
-    foreach($option_set->options as $delta => $option) {
-      if (!isset($current->option_sets[$field_name]->options[$delta])) {
-        $updates[$field_name] = TRUE;
-      }
-      else if ($current->option_sets[$field_name]->options[$delta]['option_label'] != $option['option_label']) {
+    foreach($entity_options as $delta => $option) {
+      if ($current_options[$delta]['option_label'] != $option['option_label']) {
         $updates[$field_name] = TRUE;
       }
     }

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -296,7 +296,14 @@ function personalize_fields_form_submit($form, &$form_state) {
         $option_set = new stdClass();
         $option_set->is_new = TRUE;
       } else {
-        // Make a copy so that we don't accidentally update the cached options.
+        // Changes are made to the option set to reflect the user's changes and
+        // compared against the option set for the entity in entity hooks.
+        // We need to make a copy of this object so as to not accidentally
+        // update the cached entity option sets which will be pulled for
+        // comparison.
+        // @see personalize_fields_entity_presave()
+        // PHP clone only makes a shallow copy and as a result the options
+        // are passed by reference.  Therefore we need to do our own deep copy.
         $option_set = new StdClass();
         foreach($loaded_option_set as $prop => $value) {
           if (is_array($value)) {

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -134,7 +134,7 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
   $entity = _personalize_fields_entity_from_form($form, $form_state);
   list($entity_id) = entity_extract_ids($entity_type, $entity);
   foreach ($form_state['field'] as $key => $field) {
-    $field_lang = field_language($form['#entity_type'], $entity, $key);
+    $languages[$key] = $field_lang = field_language($form['#entity_type'], $entity, $key);
     if (!empty($field[$field_lang]['field']['settings']['personalizable'])) {
       $personalized_fields[$key] = $field[$field_lang];
       drupal_alter('personalize_fields_form_element', $form[$key], $field_lang);
@@ -151,6 +151,32 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     // Load the Option Sets if we have an entity id and entity.
     if ($entity_id && ($option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key))) {
       $current_agent = $option_set->agent;
+    }
+    // Add a field for the option set label to each multivalue field.
+    for ($i=0; $i <= $form[$key][$languages[$key]]['#max_delta']; $i++) {
+      if (!empty($option_set->options[$i]['option_label'])) {
+        $default_label = $option_set->options[$i]['option_label'];
+      }
+      else if (!empty($form[$key][$languages[$key]][$i]['#default_value'])) {
+        $default_label = $form[$key][$languages[$key]][$i]['#default_value'];
+      }
+      else {
+        $default_label = personalize_generate_option_label($i);
+      }
+      $form[$key][$languages[$key]][$i]['personalize_fields_option_label'] = array(
+        '#type' => 'text',
+        '#title' => t('Administration label'),
+        '#default_value' => $default_label,
+        '#theme' => 'textfield',
+        '#autocomplete_path' => '',
+        '#theme_wrappers' => array('form_element'),
+        '#weight' => $form[$key][$field_lang][$i]['value']['#weight'] + 10,
+        '#attributes' => array(
+          'class' => array('personalize-fields-admin-option-label'),
+        ),
+        '#name' => "{$key}[{$languages[$key]}][{$i}][personalize_fields_option_label]",
+        '#input' => TRUE,
+      );
     }
   }
 
@@ -225,7 +251,7 @@ function personalize_fields_form_validate($form, &$form_state) {
 
 function personalize_fields_form_submit($form, &$form_state) {
   $values = $form_state['values'];
-
+  
   if (isset($values['agent_select']) && isset($values['personalized_fields'])) {
 
     // Extract information about the entity from the form.
@@ -249,12 +275,38 @@ function personalize_fields_form_submit($form, &$form_state) {
     }
     foreach($values['personalized_fields'] as $key => $field) {
       // Attempt to load an Option Set that's already been saved in the database.
-      if (!$option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key)) {
+      if (!$loaded_option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key)) {
         $option_set = new stdClass();
         $option_set->is_new = TRUE;
+      } else {
+        // Make a copy so that we don't accidentally update the cached options.
+        $option_set = new StdClass();
+        foreach($loaded_option_set as $prop => $value) {
+          if (is_array($value)) {
+            $option_set->{$prop} = array();
+            foreach($value as $i => $array_value) {
+              $option_set->{$prop}[] = $array_value;
+            }
+          }
+          else {
+            $option_set->{$prop} = $value;
+          }
+        }
       }
       $option_set->plugin = 'fields';
       $option_set->agent = $agent_name;
+      $current_deltas = array();
+      foreach($values[$key][LANGUAGE_NONE] as $delta => $option) {
+        if (!empty($option['value'])) {
+          $current_deltas[] = $delta;
+          $option_set->options[$delta]['option_label'] =  !empty($option['personalize_fields_option_label']) ? $option['personalize_fields_option_label'] : _personalize_generate_option_index($delta);
+        }
+      }
+      // Remove any options that are no longer included.
+      $remove = array_diff_key($option_set->options, $current_deltas);
+      foreach($remove as $delta => $value) {
+        unset($option_set->options[$delta]);
+      }
 
       // If the entity already has an ID then the options will be saved on
       // hook_entity_update.  Otherwise we add the info to the entity so that
@@ -299,25 +351,17 @@ function personalize_fields_form_personalize_admin_form_alter(&$form, &$form_sta
  */
 function personalize_fields_option_set_save($option_set, $entity_type, $entity, $field_name) {
   list($entity_id) = entity_extract_ids($entity_type, $entity);
-  // Update the Options in the Option Set.
-  $options = array();
-  foreach($entity->{$field_name}[LANGUAGE_NONE] as $delta => $option_field) {
-    $options[$delta] = isset($option_set->options[$delta]) ? $option_set->options[$delta] :
-      array(
-        'option_label' => personalize_generate_option_label($delta)
-      );
-  }
+
   // If this is a new option set and there's only one option, abort.
-  if (isset($option_set->is_new) && count($options) < 2) {
+  if (isset($option_set->is_new) && count($option_set->options) < 2) {
     return;
   }
-  elseif (count($options) < 2) {
+  elseif (count($option_set->options) < 2) {
     // Removing all but one value from a personalized multi-value field means
     // the field is no longer personalized, so delete the Option Set.
     personalize_option_set_delete($option_set->osid);
     return;
   }
-  $option_set->options = $options;
   $option_set->label = personalize_fields_generate_option_set_label($entity_type, $entity_id, $entity, $field_name);
   // Save the Option Set.
   $option_set = personalize_option_set_save($option_set);
@@ -389,20 +433,34 @@ function personalize_fields_entity_update($entity, $type) {
 /**
  * Implements hook_entity_presave().
  *
- * An option set change is significant if the number of options change.
+ * An option set change requires updating if the number of options or any of the
+ * option labels change.
+ *
+ * @todo Triggering an option set save will pause the campaign.  Do we want to
+ * do this for an option label change?
  */
 function personalize_fields_entity_presave($entity, $type) {
   $updates = &drupal_static(__FUNCTION__, array());
-  if (isset($entity->option_sets)) {
-    list($entity_id, $rev_id, $bundle) = entity_extract_ids($type, $entity);
-    // The value change is only relevant to editing entities.
-    if ($entity_id == NULL) {
-      return;
+  if (!isset($entity->option_sets)) {
+    return;
+  }
+  list($entity_id, $rev_id, $bundle) = entity_extract_ids($type, $entity);
+  // The value change is only relevant to editing entities.
+  if ($entity_id == NULL) {
+    return;
+  }
+  $entities = entity_load($type, array($entity_id), array(), TRUE);
+  $current = $entities[$entity_id];
+  foreach($entity->option_sets as $field_name => $option_set) {
+    if (count($option_set->options) != count($current->option_sets[$field_name]->options)) {
+      $updates[$field_name] = TRUE;
+      continue;
     }
-    $entities = entity_load($type, array($entity_id));
-    $current = $entities[$entity_id];
-    foreach($entity->option_sets as $field_name => $option_set) {
-      if (count($entity->{$field_name}[LANGUAGE_NONE]) !== count($current->{$field_name}[LANGUAGE_NONE])) {
+    foreach($option_set->options as $delta => $option) {
+      if (!isset($current->option_sets[$field_name]->options[$delta])) {
+        $updates[$field_name] = TRUE;
+      }
+      else if ($current->option_sets[$field_name]->options[$delta]['option_label'] != $option['option_label']) {
         $updates[$field_name] = TRUE;
       }
     }
@@ -563,8 +621,12 @@ function personalize_fields_field_attach_view_alter(&$output, $context) {
       $element['#personalize_option_set'] = $option_set;
       $element['#theme_wrappers'][] = 'personalize_options_wrapper';
       $element['#personalize_options'] = array();
+      // Use a counter variable because the option keys may not always be
+      // sequential but the element array keys are.
+      $counter = 0;
       foreach($option_set->options as $i => $option) {
-        $element['#personalize_options'][$option['option_id']] = $element[$i];
+        $element['#personalize_options'][$option['option_id']] = $element[$counter];
+        $counter++;
       }
 
     }

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -569,43 +569,6 @@ function personalize_fields_personalize_option_set_load(&$option_sets) {
 }
 
 /**
- * Implements hook_personalize_option_values_for_admin().
- */
-function personalize_fields_personalize_option_values_for_admin($option_set) {
-  if ($option_set->plugin != 'fields') {
-    return array();
-  }
-  $field_info = _personalize_fields_get_field_info_from_option_set($option_set->osid);
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', $field_info['entity_type'])
-    ->entityCondition('entity_id', $field_info['entity_id']);
-  $result = $query->execute();
-  if (empty($result)) {
-    return array();
-  }
-  $entity_info = $result[$field_info['entity_type']][$field_info['entity_id']];
-  $bundle = isset($entity_info->type) ? $entity_info->type : $entity_info->bundle;
-  $instance = field_info_instance($field_info['entity_type'], $field_info['field_name'], $bundle);
-  $field_id = $instance['field_id'];
-
-  // Use field_attach_load to populate the field value we're interested in.
-  field_attach_load($field_info['entity_type'], array($field_info['entity_id'] => $entity_info), FIELD_LOAD_CURRENT, array('field_id' => $field_id));
-
-  $items = field_get_items($field_info['entity_type'], $entity_info, $field_info['field_name']);
-  $option_values = array();
-  foreach ($option_set->options as $index => $option) {
-    if (!empty($items[$index]['safe_value'])) {
-      $option_values[$option['option_id']] = $items[$index]['safe_value'];
-    }
-    // For multi-value image fields.
-    else if (!empty($items[$index]['filename'])) {
-      $option_values[$option['option_id']] = $items[$index]['filename'];
-    }
-  }
-  return $option_values;
-}
-
-/**
  * Implements hook_field_attach_view_alter().
  */
 function personalize_fields_field_attach_view_alter(&$output, $context) {

--- a/modules/personalize_fields/tests/personalize_fields.test
+++ b/modules/personalize_fields/tests/personalize_fields.test
@@ -97,7 +97,22 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $this->drupalPost(NULL, $edit, t('Save'));
     $this->assertText(t('The campaign has been paused because you have made changes.'));
 
+    // Restart the agent and confirm that changing the option label also pauses.
+    $this->drupalGet('node/1/edit');
+    personalize_agent_set_status('test-agent', PERSONALIZE_STATUS_RUNNING);
+    $edit['article_headline[und][0][personalize_fields_option_label]'] = $this->randomName();
+    $this->drupalPost(NULL, $edit, t('Save'));
+    $this->assertText(t('The campaign has been paused because you have made changes.'));
+
+    // Restart the agent and confirm that removing an option pauses the agent.
+    $this->drupalGet('node/1/edit');
+    personalize_agent_set_status('test-agent', PERSONALIZE_STATUS_RUNNING);
+    $edit['article_headline[und][2][value]'] = '';
+    $this->drupalPost(NULL, $edit, t('Save'));
+    $this->assertText(t('The campaign has been paused because you have made changes.'));
+
     // Restart the agent and make sure that other changes do not cause pausing.
+    unset($edit['article_headline[und][2][value]']);
     $this->drupalGet('node/1/edit');
     personalize_agent_set_status('test-agent', PERSONALIZE_STATUS_RUNNING);
     $edit['title'] = $this->randomName(8);

--- a/modules/personalize_fields/tests/personalize_fields.test
+++ b/modules/personalize_fields/tests/personalize_fields.test
@@ -111,8 +111,26 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $this->drupalPost(NULL, $edit, t('Save'));
     $this->assertText(t('The campaign has been paused because you have made changes.'));
 
-    // Restart the agent and make sure that other changes do not cause pausing.
     unset($edit['article_headline[und][2][value]']);
+
+    // Now restart the agent and add/remove a field in the same form to
+    // confirm that it is still detected as a change.
+    $this->drupalGet('node/1/edit');
+    personalize_agent_set_status('test-agent', PERSONALIZE_STATUS_RUNNING);
+    $edit['article_headline[und][1][value]'] = '';
+    $edit['article_headline[und][2][value]'] = $this->randomName();
+    $edit['article_headline[und][2][personalize_fields_option_label]'] = $this->randomName();
+    $this->drupalPost(NULL, $edit, t('Save'));
+    $this->assertText(t('The campaign has been paused because you have made changes.'));
+
+    $edit['article_headline[und][1][value]'] = $edit['article_headline[und][2][value]'];
+    $edit['article_headline[und][1][personalize_fields_option_label]'] = $edit['article_headline[und][2][personalize_fields_option_label]'];
+    unset($edit['article_headline[und][2][value]']);
+    unset($edit['article_headline[und][2][personalize_fields_option_label]']);
+
+    debug($edit);
+
+    // Restart the agent and make sure that other changes do not cause pausing.
     $this->drupalGet('node/1/edit');
     personalize_agent_set_status('test-agent', PERSONALIZE_STATUS_RUNNING);
     $edit['title'] = $this->randomName(8);

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1102,7 +1102,6 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data, $a
     );
 
     $variant_number = 1;
-    $option_values = module_invoke($option_set_plugin['module'], 'personalize_option_values_for_admin', $option_set);
     foreach ($option_set->options as $option) {
       $is_winner = FALSE;
       // Determine container classes based on campaign status and winner.
@@ -1126,7 +1125,6 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data, $a
           'class' => $classes,
         ),
       );
-      $option_label = isset($option_values[$option['option_id']]) ? $option_values[$option['option_id']] : $option['option_label'];
       $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['basic'] = array(
         '#type' => 'container',
         '#attributes' => array(
@@ -1135,7 +1133,7 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data, $a
       );
       $heading = theme('personalize_admin_enumerated_item', array(
         'enum' => t('V@delta', array('@delta' => $variant_number)),
-        'title' => filter_xss($option_label),
+        'title' => filter_xss($option['option_label']),
         'title_prefix' => '"',
         'title_suffix' => '"',
         'attributes' => array(

--- a/personalize.api.php
+++ b/personalize.api.php
@@ -36,7 +36,7 @@ function hook_personalize_agent_type() {
  * CTools plugin hook for defining an Option Set type.
  *
  * An Option Set type plugin provides a mechanism for personalizing
- * a particiular type of thing in Drupal, e.g. a block in the case of
+ * a particular type of thing in Drupal, e.g. a block in the case of
  * the plugin provided by personalize_blocks module. The plugin does
  * not need to provide a class, rather it is expected to act on whatever
  * type of Drupal content it is concerned with personalizing. This will
@@ -44,11 +44,9 @@ function hook_personalize_agent_type() {
  * the time of rendering that content, and it will usually mean adding
  * personalize_options_wrapper as a theme wrapper on the element being
  * rendered. Finally, all modules providing Option Set type plugins are
- * expected to implement hook_personalize_create_new_links() and
- * hook_personalize_option_values_for_admin().
+ * expected to implement hook_personalize_create_new_links().
  *
  * @see hook_personalize_create_new_links()
- * @see hook_personalize_option_values_for_admin()
  * @see modules/personalize_blocks.module
  */
 function hook_personalize_option_set_type() {
@@ -257,20 +255,6 @@ function hook_personalize_edit_link($option_set) {
  *   The path to the delete the option set.
  */
 function hook_personalize_delete_link($option_set) {
-}
-
-/**
- * Returns option values to show in the admin UI.
- *
- * This hook must be implemented by modules providing Option Set type
- * plugins. Its purpose is to return something meaningful to display
- * for each option in the campaign edit UI so that it is clear what the
- * actual content of each option is, short of rendering that content.
- * For example, the 'block' Option Set plugin returns the block title,
- * if one has been set.
- */
-function hook_personalize_option_values_for_admin() {
-
 }
 
 /**


### PR DESCRIPTION
This includes:
- Adding an option label field to the personalize_fields module for images and text multivalue fields.
- Remove the admin hook and only use option labels throughout campaign edit page and reporting.
- Usability enhancements to auto-populate the option labels with logical labels when the content variation is added.
