### PR TITLE
Ch 410: Add preview functionality for options from campaign edit page.

### DIFF
--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1597,7 +1597,7 @@ function personalize_agent_option_sets_form_validate($form, &$form_state) {
 
   foreach ($form_values as $option_set_id => $values) {
     if (!empty($form_values[$option_set_id]['advanced']['preview_link'])) {
-      if (drupal_lookup_path('source', $form_values[$option_set_id]['advanced']['preview_link']) === FALSE) {
+      if (url_is_external($form_values[$option_set_id]['advanced']['preview_link']) || drupal_valid_path($form_values[$option_set_id]['advanced']['preview_link']) === FALSE) {
         form_set_error('option_sets][' . $option_set_id . '][advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
           '@option_set' => $form_values[$option_set_id]['advanced']['label'],
         )));

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1135,11 +1135,18 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data, $a
           'class' => array('personalize-variation-row'),
         ),
       );
+      $preview_link = '';
+      if (!empty($option_set->preview_link)) {
+        $preview_link = l('Preview', $option_set->preview_link, array(
+          'attributes' => array('target' => 'preview'),
+          'query' => array(PERSONALIZE_PRESELECTION_PARAM => personalize_stringify_osid($option_set->osid) . '--' . $option['option_id']),
+        ));
+      }
       $heading = theme('personalize_admin_enumerated_item', array(
         'enum' => t('V@delta', array('@delta' => $variant_number)),
         'title' => filter_xss($option['option_label']),
         'title_prefix' => '"',
-        'title_suffix' => '"',
+        'title_suffix' => !empty($preview_link) ? '" ' . $preview_link : '"',
         'attributes' => array(
           'class' => array('personalize-variation-col1'),
         ),
@@ -1283,6 +1290,12 @@ function personalize_agent_option_sets_form($form, &$form_state, $agent_data, $a
       '#title' => t('Shareable'),
       '#description' => 'Will display what the original visitor saw, not another variation.',
       '#default_value' => isset($option_set->stateful) ? $option_set->stateful : 0,
+    );
+    $section['option_set_' . $option_set->osid]['advanced']['preview_link'] = array(
+      '#type' => 'textfield',
+      '#title' => 'Preview link',
+      '#description' => t('Enter the internal Drupal path on your site to a page containing this content variation set. Enter &lt;front&gt; to link to the front page.'),
+      '#default_value' => !empty($option_set->preview_link) ? $option_set->preview_link : '',
     );
     // Display options to select the executor if supported.
     $executors = personalize_get_executors();
@@ -1572,8 +1585,10 @@ function personalize_agent_goals_form_submit($form, &$form_state) {
 }
 
 /**
- * Custom validation callback for Option sets form
- * Clean Explicit targeting if "Enable explicit targeting" is unchecked
+ * Custom validation callback for Option sets form.
+ *
+ * Clean Explicit targeting if "Enable explicit targeting" is unchecked.
+ * Ensure that preview links are internal and valid.
  */
 function personalize_agent_option_sets_form_validate($form, &$form_state) {
   $form_values = &$form_state['values']['option_sets'];
@@ -1581,6 +1596,13 @@ function personalize_agent_option_sets_form_validate($form, &$form_state) {
   $need_form_state_cache_clear = FALSE;
 
   foreach ($form_values as $option_set_id => $values) {
+    if (!empty($form_values[$option_set_id]['advanced']['preview_link'])) {
+      if (drupal_lookup_path('source', $form_values[$option_set_id]['advanced']['preview_link']) === FALSE) {
+        form_set_error('option_sets][' . $option_set_id . '][advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
+          '@option_set' => $form_values[$option_set_id]['advanced']['label'],
+        )));
+      }
+    }
     if (!empty($form_values[$option_set_id]['options'])) {
       foreach ($form_values[$option_set_id]['options'] as $option_name => $option) {
         if ($option['enable_explicit_targeting'] == 0) {
@@ -1616,6 +1638,9 @@ function personalize_agent_option_sets_form_submit($form, &$form_state) {
       }
       if (isset($values['advanced']['decision_name'])) {
         $option_set->decision_name = personalize_generate_machine_name($values['advanced']['decision_name']);
+      }
+      if (isset($values['advanced']['preview_link'])) {
+        $option_set->preview_link = $values['advanced']['preview_link'];
       }
       if (!isset($values['options'])) {
         personalize_option_set_save($option_set);

--- a/personalize.install
+++ b/personalize.install
@@ -149,6 +149,12 @@ function personalize_schema() {
         'serialize' => TRUE,
         'description' => 'A serialized array of additional data.',
       ),
+      'preview_link' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'description' => 'The path to a local preview page for the option set.',
+      ),
     ),
     'primary key' => array('osid'),
     'foreign keys' => array(
@@ -374,4 +380,16 @@ function personalize_update_7006() {
       ->execute();
   }
   variable_del('personalize_use_local_caching');
+}
+
+/**
+ * Add a preview link to the option sets table.
+ */
+function personalize_update_7007() {
+  db_add_field('personalize_option_sets', 'preview_link', array(
+    'type' => 'varchar',
+    'length' => 255,
+    'not null' => FALSE,
+    'description' => 'The path to a local preview page for the option set.',
+  ));
 }

--- a/personalize.module
+++ b/personalize.module
@@ -252,7 +252,7 @@ function personalize_page_build(&$page) {
       if ($option_set = personalize_option_set_load($osid)) {
         foreach ($option_set->options as $option) {
           if ($option['option_id'] === $selection) {
-            $settings['preselected'][$osid] = $option['option_id'];
+            $settings['preselected'][$osid_str] = $option['option_id'];
             break;
           }
         }
@@ -1583,6 +1583,7 @@ function personalize_option_set_save($option_set) {
     'options' => serialize($option_set->options),
     'winner' => isset($option_set->winner) ? $option_set->winner : NULL,
     'data' => serialize($option_set->data),
+    'preview_link' => isset($option_set->preview_link) ? $option_set->preview_link : NULL,
   );
 
   if (isset($option_set->osid)) {

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1482,14 +1482,13 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
     $agent_name = $agent->getMachineName();
 
     // Create block-based option set.
-    $option_set_name = $this->randomName();
     $option_sets = array();
     // Each option set will have 2 options.
     $options = array(
       array('bid' => 'comment_delta_recent'),
       array('bid' => 'system_delta_powered-by'),
     );
-    $option_sets[] = $this->createOptionSet(1, array('plugin' => 'block', 'agent' => $agent_name, 'options' => $options, 'data' => array('block_title' => $option_set_name)));
+    $option_sets[] = $this->createOptionSet(0, array('plugin' => 'block', 'agent' => $agent_name, 'options' => $options, 'data' => array('block_title' => $this->randomName())));
 
     // First verify that no preview links appear when the preview link option
     // is empty.
@@ -1501,24 +1500,27 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
       'option_sets[option_set_1][advanced][preview_link]' => 'http://google.com',
     );
     $this->drupalPost(NULL, $edit, $this->getButton('option'));
-    $this->asserText(t('The preview link for "@option_set" must be a valid internal Drupal path.', array('@option_set' => $option_set_name)));
+    $this->assertText(t('The preview link for "Option Set 1" must be a valid internal Drupal path.'));
 
     // Try adding a link to a page that does not exist.
     $edit = array(
       'option_sets[option_set_1][advanced][preview_link]' => 'node/12345',
     );
     $this->drupalPost(NULL, $edit, $this->getButton('option'));
-    $this->asserText(t('The preview link for "@option_set" must be a valid internal Drupal path.', array('@option_set' => $option_set_name)));
+    $this->assertText(t('The preview link for "Option Set 1" must be a valid internal Drupal path.'));
 
     // Add a good preview link and verify that preview links are added.
     $edit = array(
       'option_sets[option_set_1][advanced][preview_link]' => '<front>',
     );
     $this->drupalPost(NULL, $edit, $this->getButton('option'));
-    $this->asserNoText(t('The preview link for "@option_set" must be a valid internal Drupal path.', array('@option_set' => $option_set_name)));
+    $this->assertNoText(t('The preview link for "Option Set 1" must be a valid internal Drupal path.'));
 
     // In the preview link page, test that the option is pre-selected in the
     // settings passed to JavaScript.
+    $this->clickLink(t('Preview'), 1);
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['preselected']['osid-1'], 'option-B');
   }
 
   /**

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1472,6 +1472,56 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
   }
 
   /**
+   * Tests the option set preview functionality.
+   */
+  function testOptionSetPreview() {
+    // Create a new test campaign with an option set in it.
+    $admin_user = $this->drupalCreateUser(array('manage personalized content', 'access administration pages', 'administer blocks'));
+    $this->drupalLogin($admin_user);
+    $agent = $this->createTestAgent(array('agent_type' => 'test_agent'));
+    $agent_name = $agent->getMachineName();
+
+    // Create block-based option set.
+    $option_set_name = $this->randomName();
+    $option_sets = array();
+    // Each option set will have 2 options.
+    $options = array(
+      array('bid' => 'comment_delta_recent'),
+      array('bid' => 'system_delta_powered-by'),
+    );
+    $option_sets[] = $this->createOptionSet(1, array('plugin' => 'block', 'agent' => $agent_name, 'options' => $options, 'data' => array('block_title' => $option_set_name)));
+
+    // First verify that no preview links appear when the preview link option
+    // is empty.
+    $this->drupalGet("admin/structure/personalize/manage/{$agent_name}/edit");
+    $this->assertNoLink(t('Preview'));
+
+    // Try adding a link to an external page.
+    $edit = array(
+      'option_sets[option_set_1][advanced][preview_link]' => 'http://google.com',
+    );
+    $this->drupalPost(NULL, $edit, $this->getButton('option'));
+    $this->asserText(t('The preview link for "@option_set" must be a valid internal Drupal path.', array('@option_set' => $option_set_name)));
+
+    // Try adding a link to a page that does not exist.
+    $edit = array(
+      'option_sets[option_set_1][advanced][preview_link]' => 'node/12345',
+    );
+    $this->drupalPost(NULL, $edit, $this->getButton('option'));
+    $this->asserText(t('The preview link for "@option_set" must be a valid internal Drupal path.', array('@option_set' => $option_set_name)));
+
+    // Add a good preview link and verify that preview links are added.
+    $edit = array(
+      'option_sets[option_set_1][advanced][preview_link]' => '<front>',
+    );
+    $this->drupalPost(NULL, $edit, $this->getButton('option'));
+    $this->asserNoText(t('The preview link for "@option_set" must be a valid internal Drupal path.', array('@option_set' => $option_set_name)));
+
+    // In the preview link page, test that the option is pre-selected in the
+    // settings passed to JavaScript.
+  }
+
+  /**
    * Tests that explicit targeting options are properly created and saved.
    */
   function testExplicitTargeting() {


### PR DESCRIPTION
_NOTE_ Found what appears to be a bug in personalize.module that preselected options were being stored keyed by option ids when creating the Drupal.settings, but javascript was looking for the stringified version of the option ids.

Test pass but wanted to point this out in case there is known affected functionality....
