### PR TITLE
Ch 301: Add an affordance in the UI for personalizable fields

### DIFF
--- a/modules/personalize_fields/css/personalize_fields.admin-rtl.css
+++ b/modules/personalize_fields/css/personalize_fields.admin-rtl.css
@@ -1,0 +1,5 @@
+/* Indicates that a field is personalized */
+.personalize-fields-personalized.field-type-image .fieldset-legend:after,
+.personalize-fields-personalized.field-type-text .personalize-fields-expanded > .form-item > label:after {
+  margin-right: .7em; /* RTL */
+}

--- a/modules/personalize_fields/css/personalize_fields.admin.theme.css
+++ b/modules/personalize_fields/css/personalize_fields.admin.theme.css
@@ -1,0 +1,9 @@
+/* Indicates that a field is personalized */
+.personalize-fields-personalized.field-type-image .fieldset-legend:after,
+.personalize-fields-personalized.field-type-text .personalize-fields-expanded > .form-item > label:after {
+  content: 'Personalized';
+  color: #2fa6e5;
+  margin-left: .7em; /* LTR */
+  font-weight: bold;
+  text-transform: capitalize;
+}

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -137,6 +137,7 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     $languages[$key] = $field_lang = field_language($form['#entity_type'], $entity, $key);
     if (!empty($field[$field_lang]['field']['settings']['personalizable'])) {
       $personalized_fields[$key] = $field[$field_lang];
+      $form[$key]['#attributes']['class'][] = 'personalize-fields-personalized';
       drupal_alter('personalize_fields_form_element', $form[$key], $field_lang);
     }
   }
@@ -145,7 +146,9 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
     return;
   }
 
-  $form['#attached']['js'][] = drupal_get_path('module', 'personalize_fields') . '/js/personalize_fields.admin.js';
+  $path = drupal_get_path('module', 'personalize_fields');
+  $form['#attached']['js'][] = $path . '/js/personalize_fields.admin.js';
+  $form['#attached']['css'][] = $path . '/css/personalize_fields.admin.theme.css';
 
   // Load the default agent if one is already set.
   $current_agent = NULL;

--- a/modules/personalize_fields/tests/personalize_fields.test
+++ b/modules/personalize_fields/tests/personalize_fields.test
@@ -23,7 +23,7 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
   }
 
   /**
-   * Tests adding a personalizeed field to a node and deleting the node.
+   * Tests adding a personalized field to a node and deleting the node.
    */
   function testPersonalizeFields() {
     $admin_user = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'administer content types', 'administer nodes', 'bypass node access', 'manage personalized content'));
@@ -411,5 +411,54 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
 
     $node = node_load(4);
     $this->assertFalse($node);
+  }
+
+  /**
+   * Test that a personalized indicator is added only to personalized fields.
+   */
+  function testPersonalizedFieldIndicator() {
+    $admin_user = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'administer content types', 'administer nodes', 'bypass node access', 'manage personalized content'));
+    $this->drupalLogin($admin_user);
+    // Add non-personalized multi-value field to the article node type.
+    $field = array(
+      'type' => 'text',
+      'field_name' => 'article_headline',
+      'cardinality' => 2,
+      'settings' => array(
+        'personalizable' => 0,
+      ),
+    );
+    field_create_field($field);
+    $instance = array(
+      'field_name' => 'article_headline',
+      'entity_type' => 'node',
+      'label' => 'Regular Headline',
+      'bundle' => 'article',
+      'required' => FALSE
+    );
+    field_create_instance($instance);
+    $this->drupalGet('node/add/article');
+    $this->assertNoPattern('/class=".*?personalize-fields-personalized.*?"/', 'personalize-fields-personalized class not found');
+
+    // Add personalized multi-value field to the article node type.
+    $field = array(
+      'type' => 'text',
+      'field_name' => 'personalized_article_headline',
+      'cardinality' => 2,
+      'settings' => array(
+        'personalizable' => 1,
+      ),
+    );
+    field_create_field($field);
+    $instance = array(
+      'field_name' => 'personalized_article_headline',
+      'entity_type' => 'node',
+      'label' => 'Personalized Headline',
+      'bundle' => 'article',
+      'required' => FALSE
+    );
+    field_create_instance($instance);
+    $this->drupalGet('node/add/article');
+    $this->assertPattern('/class=".*?personalize-fields-personalized.*?"/', 'personalize-fields-personalized class found');
   }
 }


### PR DESCRIPTION
NOTE: Given that this is likely to change soon to an icon, I took the path of just adding a class and putting text directly in the CSS.  Normally I wouldn't do that, but it was going to be quite messy to go in and add it to the label fields (particularly for the image fieldset) and I didn't want to muck it up that much in this situation.
