### PR TITLE
CH-468: Allow execution of javascript as content variations

### DIFF
--- a/js/personalize.js
+++ b/js/personalize.js
@@ -113,6 +113,9 @@
    */
   Drupal.personalize.executors.show = {
     'execute': function ($option_set, choice_name, osid, preview) {
+      if ($option_set.length == 0 ) {
+        return;
+      }
       var $option_source = $('script[type="text/template"]', $option_set);
       var element = $option_source.get(0);
       var json = element.innerText;
@@ -158,6 +161,9 @@
    */
   Drupal.personalize.executors.callback = {
   'execute': function($option_set, choice_name, osid, preview) {
+    if ($option_set.length == 0 ) {
+      return;
+    }
     // Set up such that Drupal ajax handling can be utilized without a trigger.
     var custom_settings = {};
     custom_settings.url = '/personalize/option_set/' + osid + '/' + choice_name + '/ajax';
@@ -641,13 +647,9 @@
     }
     // If we now have a chosen option, just call the executor and be done.
     if (chosenOption !== null) {
-      // We need the check for $option_set.length because the Option Set isn't
-      // necessarily in the DOM - it could be part of an MVT where not all Option
-      // Sets are present on the page.
-      if ($option_set.length > 0 && Drupal.personalize.executors.hasOwnProperty(executor)) {
+      if (Drupal.personalize.executors.hasOwnProperty(executor)) {
         Drupal.personalize.executors[executor].execute($option_set, chosenOption, osid);
       }
-      // Either way, no further processing should take place.
       return;
     }
 
@@ -684,18 +686,12 @@
     agents[agent_name].decisionPoints[decision_point].callbacks[decision_name] =
       agents[agent_name].decisionPoints[decision_point].callbacks[decision_name] || [];
     // Add a callback for this option set to the decision point.
-    if ($option_set.length > 0) {
-      agents[agent_name].decisionPoints[decision_point].callbacks[decision_name].push(function(decision) {
-        Drupal.personalize.executors[executor].execute($option_set, decision, osid);
-        // Fire an event so other code can respond to the decision.
-        $(document).trigger('personalizeDecision', [$option_set, decision, osid]);
-      });
-    }
-    else {
-      // If it's a phantom Option Set, i.e. one that hasn't actually been rendered on
-      // the page, just pass an empty callback function.
-      agents[agent_name].decisionPoints[decision_point].callbacks[decision_name].push(function(decision) {});
-    }
+    agents[agent_name].decisionPoints[decision_point].callbacks[decision_name].push(function(decision) {
+      Drupal.personalize.executors[executor].execute($option_set, decision, osid);
+      // Fire an event so other code can respond to the decision.
+      $(document).trigger('personalizeDecision', [$option_set, decision, osid]);
+    });
+
   }
 
   // Keeps track of processed listeners so we don't subscribe them more than once.

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -14,7 +14,7 @@
         // is the control option.
         var isControl = choice_name == Drupal.settings.personalize_elements.controlOptionName;
         var selectedContent = choices[choiceIndex]['personalize_elements_content'];
-        if ($option_set.length == 0 || element.variation_type == 'runJS') {
+        if ($option_set.length == 0 && element.variation_type != 'runJS') {
           // Only the runJS can do something with an empty Option Set.
           return;
         }

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -14,6 +14,10 @@
         // is the control option.
         var isControl = choice_name == Drupal.settings.personalize_elements.controlOptionName;
         var selectedContent = choices[choiceIndex]['personalize_elements_content'];
+        if ($option_set.length == 0 || element.variation_type == 'runJS') {
+          // Only the runJS can do something with an empty Option Set.
+          return;
+        }
         Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid, preview);
         Drupal.personalize.executorCompleted($option_set, choice_name, osid);
       }
@@ -21,6 +25,17 @@
   };
 
   Drupal.personalizeElements = {};
+
+  Drupal.personalizeElements.runJS = {
+    execute : function ($selector, selectedContent, isControl, osid) {
+      if (!isControl) {
+        // The contents of the selectedContent variable were written by someone
+        // who was explicitly given permission to write JavaScript to be executed
+        // on this site. Mitigating the evil of the eval.
+        eval(selectedContent);
+      }
+    }
+  };
 
   Drupal.personalizeElements.replaceHtml = {
     controlContent : {},

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -263,7 +263,7 @@ function personalize_elements_add_option_ajax_callback($form, &$form_state) {
  * Validation callback for the element creation/edit form.
  */
 function personalize_elements_form_validate($form, &$form_state) {
-  $values = $form_state['values'];
+  $values = &$form_state['values'];
   if ($values['op'] == t('Save')) {
     if (empty($values['variation_type'])) {
       form_set_error('variation_type', t('You must choose a variation type'));
@@ -285,7 +285,13 @@ function personalize_elements_form_validate($form, &$form_state) {
     // If an option has an empty label and empty content, it will be removed so
     // we need to count how many non-empty options there are.
     $non_empty_options = 0;
-    foreach ($values['options'] as $i => $option) {
+
+    $allowed_html = variable_get('personalize_elements_allowed_html', _personalize_elements_get_default_allowed_tags());
+    $allowed_tags = preg_split('/\s+|<|>/', $allowed_html, -1, PREG_SPLIT_NO_EMPTY);
+    // Remove empty options.
+    foreach ($values['options'] as $i => &$option) {
+      // First, filter out any disallowed html tags.
+      $option['personalize_elements_content'] = filter_xss($option['personalize_elements_content'], $allowed_tags);
       if (!empty($option['option_label']) || !empty($option['personalize_elements_content'])) {
         $non_empty_options++;
         if (empty($option['option_label'])) {
@@ -360,6 +366,7 @@ function personalize_elements_convert_form_values_to_option_set($values) {
       unset($options[$i]);
     }
   }
+  // Re-key the array in case some items were removed.
   $options = array_values($options);
   if ($options[0]['option_label'] === PERSONALIZE_ELEMENTS_CONTROL_OPTION_LABEL) {
     // This will get added back on if needed, after the other options have
@@ -411,4 +418,24 @@ function personalize_elements_element_delete_submit($form, &$form_state) {
   personalize_option_set_delete($form_state['values']['osid']);
   drupal_set_message(t('The personalized element %name has been removed.', array('%name' => $form_state['values']['title'])));
   $form_state['redirect'] = 'admin/structure/personalize-elements';
+}
+
+/**
+ * Menu callback for the configuration form.
+ */
+function personalize_elements_configuration_form($form, &$form_state) {
+  $form['contexts'] = array(
+    '#title' => t('Allowed HTML tags'),
+    '#description' => t('Some Personalize Elements operations involve replacing existing HTML with new HTML, or appending/prepending HTML. Tags other than those included here will be filtered out.'),
+    '#type' => 'textarea',
+    '#default_value' => variable_get('personalize_elements_allowed_html', _personalize_elements_get_default_allowed_tags()),
+  );
+  return system_settings_form($form);
+}
+
+/**
+ * Returns the HTML tags that are enabled by default.
+ */
+function _personalize_elements_get_default_allowed_tags() {
+  return '<p> <div> <img> <a> <br> <caption> <col> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h1> <h2> <h3> <h4> <h5> <h6> <pre> <span> <table> <tbody> <th> <tr>';
 }

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -391,7 +391,7 @@ function personalize_elements_convert_form_values_to_option_set($values) {
     'executor' => 'personalizeElements',
     'options' => $options,
     'data' => array(
-      'personalize_elements_selector' => $values['selector'],
+      'personalize_elements_selector' => isset($values['selector']) ? $values['selector'] : '',
       'personalize_elements_type' => $values['variation_type'],
       'pages' => $values['pages'],
     )

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -288,10 +288,15 @@ function personalize_elements_form_validate($form, &$form_state) {
 
     $allowed_html = variable_get('personalize_elements_allowed_html', _personalize_elements_get_default_allowed_tags());
     $allowed_tags = preg_split('/\s+|<|>/', $allowed_html, -1, PREG_SPLIT_NO_EMPTY);
+    $changed = 0;
     // Remove empty options.
     foreach ($values['options'] as $i => &$option) {
       // First, filter out any disallowed html tags.
-      $option['personalize_elements_content'] = filter_xss($option['personalize_elements_content'], $allowed_tags);
+      $filtered = filter_xss($option['personalize_elements_content'], $allowed_tags);
+      if ($filtered !== $option['personalize_elements_content']) {
+        $changed++;
+      }
+      $option['personalize_elements_content'] = $filtered;
       if (!empty($option['option_label']) || !empty($option['personalize_elements_content'])) {
         $non_empty_options++;
         if (empty($option['option_label'])) {
@@ -304,6 +309,9 @@ function personalize_elements_form_validate($form, &$form_state) {
     }
     if ($non_empty_options < $num_required) {
       form_set_error('', t('You must have at least 2 options for an option set'));
+    }
+    if ($changed) {
+      drupal_set_message(t('Disallowed HTML tags were removed from @variations.', array('@variations' => format_plural($changed, '1 variation', '@count variations', array('@count' => $changed)))), 'warning');
     }
   }
 }

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -424,7 +424,7 @@ function personalize_elements_element_delete_submit($form, &$form_state) {
  * Menu callback for the configuration form.
  */
 function personalize_elements_configuration_form($form, &$form_state) {
-  $form['contexts'] = array(
+  $form['personalize_elements_allowed_html'] = array(
     '#title' => t('Allowed HTML tags'),
     '#description' => t('Some Personalize Elements operations involve replacing existing HTML with new HTML, or appending/prepending HTML. Tags other than those included here will be filtered out.'),
     '#type' => 'textarea',

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -110,18 +110,14 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
     '#default_value' => isset($option_set->label) ? $option_set->label : '',
   );
 
-  $form['selector'] = array(
-    '#title' => t('Selector'),
-    '#description' => t('The selector to find the element to personalize.'),
-    '#type' => 'textfield',
-    '#required' => TRUE,
-    '#default_value' => isset($option_set->data['personalize_elements_selector']) ? $option_set->data['personalize_elements_selector'] : '',
-  );
-
   $variation_type_options = array();
+  $selector_states = array();
   $variation_types = module_invoke_all('personalize_elements_variation_types');
-  foreach ($variation_types as $type => $label) {
-    $variation_type_options[$type] = $label;
+  foreach ($variation_types as $type => $info) {
+    $variation_type_options[$type] = $info['label'];
+    if ($info['needs_selector']) {
+      $selector_states[] = array('select[name="variation_type"]' => array("value" => $type));
+    }
   }
 
   $form['variation_type'] = array(
@@ -130,6 +126,19 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
     '#options' => array('' => t('Select a variation type...')) + $variation_type_options,
     '#default_value' => isset($option_set->data['personalize_elements_type']) ? $option_set->data['personalize_elements_type'] : '',
   );
+
+  if (!empty($selector_states)) {
+    $form['selector'] = array(
+      '#title' => t('Selector'),
+      '#description' => t('The selector to find the element to personalize.'),
+      '#type' => 'textfield',
+      '#default_value' => isset($option_set->data['personalize_elements_selector']) ? $option_set->data['personalize_elements_selector'] : '',
+    );
+    $form['selector']['#states'] = array(
+      'visible' => $selector_states,
+      'required' => $selector_states,
+    );
+  }
 
   // If the "Add another" button was clicked, we need to increment the number of
   // options by one.

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -72,7 +72,7 @@ function personalize_elements_permission() {
   $permissions = array(
     'use advanced personalize elements features' => array(
       'title' => t('Use advanced Personalize Elements features'),
-      'description' => t('Write the JavaScript to be run for Option Sets whose options involve executing different pieces of JavaScript.'),
+      'description' => t('Includes permission to write JavaScript to be executed for content variations and modifying the set of allowed HTML tags.'),
     ),
   );
 

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -53,7 +53,30 @@ function personalize_elements_menu() {
     'type' => MENU_LOCAL_TASK,
     'file' => 'personalize_elements.admin.inc',
   );
+  $items['admin/config/content/personalize/personalize-elements'] = array(
+    'type' => MENU_LOCAL_TASK,
+    'title' => 'Personalize Elements',
+    'description' => 'Configuration settings for Personalize Elements module.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('personalize_elements_configuration_form'),
+    'access arguments' => array('use advanced personalize elements features'),
+    'file' => 'personalize_elements.admin.inc',
+  );
   return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function personalize_elements_permission() {
+  $permissions = array(
+    'use advanced personalize elements features' => array(
+      'title' => t('Use advanced Personalize Elements features'),
+      'description' => t('Write the JavaScript to be run for Option Sets whose options involve executing different pieces of JavaScript.'),
+    ),
+  );
+
+  return $permissions;
 }
 
 /**
@@ -171,8 +194,8 @@ function personalize_elements_personalize_delete_link($option_set) {
 /**
  * Implements hook_personalize_elements_variation_types().
  */
-function personalize_elements_personalize_elements_variation_types() {
-  return array(
+function personalize_elements_personalize_elements_variation_types($filter_by_perms = TRUE) {
+  $types = array(
     'replaceHtml' => array(
       'label' => t('Replace the html'),
       'needs_selector' => TRUE,
@@ -189,11 +212,14 @@ function personalize_elements_personalize_elements_variation_types() {
       'label' => t('Prepend HTML'),
       'needs_selector' => TRUE,
     ),
-    'runJS' => array(
+  );
+  if (user_access('use advanced personalize elements features') || !$filter_by_perms) {
+    $types['runJS'] = array(
       'label' => t('Run JavaScript code'),
       'needs_selector' => FALSE,
-    ),
-  );
+    );
+  }
+  return $types;
 }
 
 /**

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -173,10 +173,26 @@ function personalize_elements_personalize_delete_link($option_set) {
  */
 function personalize_elements_personalize_elements_variation_types() {
   return array(
-    'replaceHtml' => t('Replace the html'),
-    'addClass' => t('Add a class'),
-    'appendHtml' => t('Append HTML'),
-    'prependHtml' => t('Prepend HTML'),
+    'replaceHtml' => array(
+      'label' => t('Replace the html'),
+      'needs_selector' => TRUE,
+    ),
+    'addClass' => array(
+      'label' => t('Add a class'),
+      'needs_selector' => TRUE,
+    ),
+    'appendHtml' => array(
+      'label' => t('Append HTML'),
+      'needs_selector' => TRUE,
+    ),
+    'prependHtml' => array(
+      'label' => t('Prepend HTML'),
+      'needs_selector' => TRUE,
+    ),
+    'runJS' => array(
+      'label' => t('Run JavaScript code'),
+      'needs_selector' => FALSE,
+    ),
   );
 }
 

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -116,6 +116,8 @@ function personalize_elements_page_build(&$page) {
     $elements[$js_id] = array(
       'selector' => $option_set->data['personalize_elements_selector'],
       'variation_type' => $option_set->data['personalize_elements_type'],
+      // The 'runJS' variation type cannot be previewed in the normal way.
+      'previewable' => $option_set->data['personalize_elements_type'] !== 'runJS',
     );
   }
   if (empty($elements)) {

--- a/modules/personalize_elements/tests/personalize_elements.test
+++ b/modules/personalize_elements/tests/personalize_elements.test
@@ -19,10 +19,50 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     parent::setUp(array('personalize_elements', 'personalize_test'));
   }
 
+  function testPersonalizeElementsPermissions() {
+    // Log in as a user with permission to do personalization but without the permission
+    // to use the advanced Personalize Elements stuff.
+    $marketer = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'manage personalized content'));
+    $this->drupalLogin($marketer);
+    $this->drupalGet('admin/config/content/personalize/personalize-elements');
+    $this->assertResponse(403);
+    $this->drupalGet('admin/structure/personalize-elements/add');
+    // Find the "Variation type" select list and confirm that 'runJS' is not one of
+    // the options.
+    $elements = $this->xpath('//select[@id=:id]', array(':id' => 'edit-variation-type'));
+    $options = array();
+    foreach ($elements as $field) {
+      $items = $this->getAllOptions($field);
+      foreach ($items as $item) {
+        $options[] = $item['value'];
+      }
+    }
+    $this->assertFalse(in_array('runJS', $options));
+
+    // Now log in as a user who does have permission to do the advanced Personalize Elements
+    // stuff.
+    $this->drupalLogout();
+    $advanced_user = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'manage personalized content', 'use advanced personalize elements features'));
+    $this->drupalLogin($advanced_user);
+    $this->drupalGet('admin/config/content/personalize/personalize-elements');
+    $this->assertResponse(200);
+    $this->drupalGet('admin/structure/personalize-elements/add');
+    $elements = $this->xpath('//select[@id=:id]', array(':id' => 'edit-variation-type'));
+
+    $options = array();
+    foreach ($elements as $field) {
+      $items = $this->getAllOptions($field);
+      foreach ($items as $item) {
+        $options[] = $item['value'];
+      }
+    }
+    $this->assertTrue(in_array('runJS', $options));
+  }
+
   /**
    * Tests adding and editing Personalize Elements Option Sets.
    */
-  function testPersonalizeElementsConfiguration() {
+  function testPersonalizeElementsAdmin() {
     $admin_user = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'manage personalized content'));
     $this->drupalLogin($admin_user);
     $edit = array(
@@ -40,9 +80,9 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $this->drupalPost(NULL, array(), t('Add another'));
     $this->assertFieldByName('options[1][option_label]', personalize_generate_option_label(1));
     $edit['options[0][option_label]'] = 'first-option';
-    $edit['options[0][personalize_elements_content]'] = 'some content';
+    $edit['options[0][personalize_elements_content]'] = '<p>some content</p>';
     $edit['options[1][option_label]'] = 'second-option';
-    $edit['options[1][personalize_elements_content]'] = 'other content';
+    $edit['options[1][personalize_elements_content]'] = '<div>other content</div>';
     $this->drupalPost(NULL, $edit, t('Save'));
 
     $option_set = personalize_option_set_load(1);
@@ -54,12 +94,11 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $option_set = personalize_option_set_load(1, TRUE);
     $this->assertEqual(3, count($option_set->options));
 
-    // Add another element and assert that all the options have the expected
-    // settings.
+    // Add another element with a script tag.
     $this->drupalGet('admin/structure/personalize-elements/manage/1/edit');
     $this->drupalPost(NULL, array(), t('Add another'));
     $edit = array();
-    $edit['options[3][personalize_elements_content]'] = 'moar content';
+    $edit['options[3][personalize_elements_content]'] = '<script type="text/javascript">alert("xss");</script>';
     $this->drupalPost(NULL, $edit, t('Save'));
     $option_set = personalize_option_set_load(1, TRUE);
     $control_option = array(
@@ -72,17 +111,17 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
       1 => array(
         'option_id' => 'first-option',
         'option_label' => 'first-option',
-        'personalize_elements_content' => 'some content',
+        'personalize_elements_content' => '<p>some content</p>',
       ),
       2 => array(
         'option_id' => 'second-option',
         'option_label' => 'second-option',
-        'personalize_elements_content' => 'other content',
+        'personalize_elements_content' => '<div>other content</div>',
       ),
       3 => array(
         'option_id' => 'option-c',
         'option_label' => 'Option C',
-        'personalize_elements_content' => 'moar content',
+        'personalize_elements_content' => 'alert("xss");',
       ),
     );
     $this->assertEqual(count($expected), count($option_set->options));
@@ -168,6 +207,24 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $option_set = personalize_option_set_load(1);
     $this->assertEqual(2, count($option_set->options));
     $this->assertEqual($machine_name, $option_set->agent);
+  }
+
+  function testPersonalizeElementsConfig() {
+    $advanced_user = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'manage personalized content', 'use advanced personalize elements features'));
+    $this->drupalLogin($advanced_user);
+    $option_set = $this->createPersonalizedElement(array('options[0][personalize_elements_content]' => '<div class="stuff">ohai</div>', 'options[1][personalize_elements_content]' => '<a href="/">kthxbai</a>'), FALSE);
+    $this->assertEqual('<div class="stuff">ohai</div>', $option_set->options[0]['personalize_elements_content']);
+    $this->assertEqual('<a href="/">kthxbai</a>', $option_set->options[1]['personalize_elements_content']);
+    // Now change the configuration to restrict the allowed tags.
+    $this->drupalPost('admin/config/content/personalize/personalize-elements', array('personalize_elements_allowed_html' => '<a> <em>'), t('Save configuration'));
+    $allowed_tags = variable_get('personalize_elements_allowed_html', array());
+    $this->assertEqual('<a> <em>', $allowed_tags);
+
+    // Resave the personalized element and confirm that disallowed tags are stripped out.
+    $this->drupalPost('admin/structure/personalize-elements/manage/1/edit', array(), t('Save'));
+    $option_set = personalize_option_set_load(1, TRUE);
+    $this->assertEqual('ohai', $option_set->options[0]['personalize_elements_content']);
+    $this->assertEqual('<a href="/">kthxbai</a>', $option_set->options[1]['personalize_elements_content']);
   }
 
   /**

--- a/modules/personalize_elements/tests/personalize_elements.test
+++ b/modules/personalize_elements/tests/personalize_elements.test
@@ -100,6 +100,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $edit = array();
     $edit['options[3][personalize_elements_content]'] = '<script type="text/javascript">alert("xss");</script>';
     $this->drupalPost(NULL, $edit, t('Save'));
+    $this->assertText(t('Disallowed HTML tags were removed from 1 variation.'));
     $option_set = personalize_option_set_load(1, TRUE);
     $control_option = array(
       'option_id' => PERSONALIZE_ELEMENTS_CONTROL_OPTION_ID,


### PR DESCRIPTION
The changes in personalize.js have to do with the fact that it is now perfectly legitimate to have an option set on the page for which there is no corresponding markup. Usually there would be a div with an id like '#personalize-osid-123' and we pass a jQuery object based on this selector to the executor. Previously, the only reason this could be empty was if the option set was part of an MVT, where the other option set(s) were being rendered but this one for some reason didn't exist on the page. But the arbitrary js functionality is our first example of an option set that _is_ on the page but for which there is no div. So now it is up to the executor in question to deal with the possibility of receiving an empty jQuery object for the option set.

It's also worth mentioning here that previewing won't really work for an option set using arbitrary JS as we've no way of going back to the control option (if there is one) after running one of the other options. Not sure what can be done about that.
