### PR TITLE
Ch 439: Enable different cache expiration settings for visitor context options.

### DIFF
--- a/includes/personalize.classes.inc
+++ b/includes/personalize.classes.inc
@@ -385,6 +385,10 @@ interface PersonalizeContextInterface {
    *   - name A human-readable name for the option
    *   - (optional) group An optional group name that the option should be
    *     categorized under.
+   *   - (optional) cache_type: indicates the type of web storage caching (if
+   *     available); one of "session", "local", "none" (default).
+   *   - (optional) cache_expiration:  the number of minutes that this option
+   *     should remain in the cache.  Only valid when cache_type = "local".
    */
   public static function getOptions();
 

--- a/includes/personalize.classes.inc
+++ b/includes/personalize.classes.inc
@@ -388,7 +388,8 @@ interface PersonalizeContextInterface {
    *   - (optional) cache_type: indicates the type of web storage caching (if
    *     available); one of "session", "local", "none" (default).
    *   - (optional) cache_expiration:  the number of minutes that this option
-   *     should remain in the cache.  Only valid when cache_type = "local".
+   *     should remain in the cache or none to keep indefinitely.  Only valid
+   *     when cache_type = "local".
    */
   public static function getOptions();
 

--- a/js/personalize.js
+++ b/js/personalize.js
@@ -747,6 +747,8 @@
 
   /*
    * W . E . B   S . T . O . R . A . G . E
+   *
+   * Inspired by https://github.com/pamelafox/lscache.
    */
   Drupal.personalize.storage = Drupal.personalize.storage || {};
   Drupal.personalize.storage.buckets = Drupal.personalize.storage.buckets || {};
@@ -794,6 +796,7 @@
           if (expirationSetting === 'none') {
             data.expires = NaN;
           } else {
+            // Expiration is set in minutes but used in milliseconds.
             data.expires = expirationSetting * 60 * 1000;
           }
         }

--- a/js/personalize.js
+++ b/js/personalize.js
@@ -435,20 +435,35 @@
     }
   }
 
+  /**
+   * Generates a standardized key format for a decision point to use for
+   * persisted storage.
+   *
+   * @param agent_name
+   *   The name of the agent for decisions.
+   * @param point
+   *   The decision point name.
+   * @returns {string}
+   *   The formatted key name to be used in persistent storage.
+   */
+  function generateDecisionStorageKey(agent_name, point) {
+    return agent_name + Drupal.personalize.storage.utilities.cacheSeparator + point;
+  }
+
   function readDecisionsfromStorage(agent_name, point) {
     if (!Drupal.settings.personalize.agent_map[agent_name].cache_decisions) {
       return null;
     }
-    var bucket = Drupal.personalize.storage.utilities.getBucket(Drupal.personalize.storage.utilities.getDecisionBucketName(agent_name));
-    return bucket.read(point);
+    var bucket = Drupal.personalize.storage.utilities.getBucket('decisions');
+    return bucket.read(generateDecisionStorageKey(agent_name, point));
   }
 
   function writeDecisionsToStorage(agent_name, point, decisions) {
     if (!sessionID || !Drupal.settings.personalize.agent_map[agent_name].cache_decisions) {
       return;
     }
-    var bucket = Drupal.personalize.storage.utilities.getBucket(Drupal.personalize.storage.utilities.getDecisionBucketName(agent_name));
-    bucket.write(point, decisions);
+    var bucket = Drupal.personalize.storage.utilities.getBucket('decisions');
+    bucket.write(generateDecisionStorageKey(agent_name, point), decisions);
   }
 
   /**
@@ -750,18 +765,6 @@
         return (expiration_minutes * 60 * 1000);
       }
       return 0;
-    },
-
-    /**
-     * Gets the name for an agent's decision bucket.
-     *
-     * @param agent
-     *   The agent to store the decisions for.
-     * @returns {string}
-     *   A formatted bucket name.
-     */
-    getDecisionBucketName: function (agent) {
-      return 'decisions' + this.cacheSeparator + agent;
     },
 
     /**

--- a/js/personalize.js
+++ b/js/personalize.js
@@ -356,12 +356,14 @@
    *
    * @param key
    *   The name of the context item to retrieve.
+   * @param context
+   *   The type of visitor context for the key.
    * @returns {*}
    *   The value of the specified context item or null if not found or
    *   if not configured to store visitor context in localStorage.
    */
-  Drupal.personalize.visitor_context_read = function(key) {
-    var bucketName = Drupal.personalize.storage.utilities.generateVisitorContextBucketName(key);
+  Drupal.personalize.visitor_context_read = function(key, context) {
+    var bucketName = Drupal.personalize.storage.utilities.generateVisitorContextBucketName(key, context);
     var bucket = Drupal.personalize.storage.utilities.getBucket(bucketName);
     return bucket.read(key);
   };
@@ -374,13 +376,15 @@
    *
    * @param key
    *   The name of the context item to store.
+   * @param context
+   *   The type of visitor context for the key.
    * @param value
    *   The value of the context item to store.
    * @param overwrite
    *   True to overwrite existing values, false not to overwrite; default true.
    */
-  Drupal.personalize.visitor_context_write = function(key, value, overwrite) {
-    var bucketName = Drupal.personalize.storage.utilities.generateVisitorContextBucketName(key);
+  Drupal.personalize.visitor_context_write = function(key, context, value, overwrite) {
+    var bucketName = Drupal.personalize.storage.utilities.generateVisitorContextBucketName(key, context);
     var bucket = Drupal.personalize.storage.utilities.getBucket(bucketName);
     if (overwrite === false) {
       var current = bucket.read(key);
@@ -764,11 +768,13 @@
      *
      * @param key
      *   The key to store.
+     * @param context
+     *   The type of visitor context for the key.
      * @returns string
      *   The standardized bucket name.
      */
-    generateVisitorContextBucketName: function (key) {
-      return 'visitor_context' + this.cacheSeparator + key;
+    generateVisitorContextBucketName: function (key, context) {
+      return 'visitor_context' + this.cacheSeparator + context + this.cacheSeparator + key;
     },
 
     /**

--- a/js/personalize.js
+++ b/js/personalize.js
@@ -382,7 +382,7 @@
   Drupal.personalize.visitor_context_write = function(key, value, overwrite) {
     var bucketName = Drupal.personalize.storage.utilities.generateVisitorContextBucketName(key);
     var bucket = Drupal.personalize.storage.utilities.getBucket(bucketName);
-    if (typeof overwrite === false) {
+    if (overwrite === false) {
       var current = bucket.read(key);
       if (current !== null) {
         // A value already exists and we are not allowed to overwrite.

--- a/modules/personalize_url_context/js/personalize_url_context.js
+++ b/modules/personalize_url_context/js/personalize_url_context.js
@@ -11,6 +11,7 @@
     var baseUrl = Drupal.settings.personalize_url_context.base_url, referrer = document.referrer;
     if (referrer && referrer.indexOf(baseUrl) == -1) {
       Drupal.personalize.visitor_context_write('referrer_url', referrer);
+      Drupal.personalize.visitor_context_write('original_referrer_url', referrer, false);
     }
     initialized = true;
   }

--- a/modules/personalize_url_context/js/personalize_url_context.js
+++ b/modules/personalize_url_context/js/personalize_url_context.js
@@ -1,6 +1,7 @@
 (function ($) {
 
   var initialized = false;
+  var context = 'querystring_context';
 
   function init() {
     for (var name in Drupal.settings.personalize_url_context.querystring_params) {
@@ -10,8 +11,8 @@
     }
     var baseUrl = Drupal.settings.personalize_url_context.base_url, referrer = document.referrer;
     if (referrer && referrer.indexOf(baseUrl) == -1) {
-      Drupal.personalize.visitor_context_write('referrer_url', referrer);
-      Drupal.personalize.visitor_context_write('original_referrer_url', referrer, false);
+      Drupal.personalize.visitor_context_write('referrer_url', context, referrer);
+      Drupal.personalize.visitor_context_write('original_referrer_url', context, referrer, false);
     }
     initialized = true;
   }
@@ -34,7 +35,7 @@
       var i, context_values = {};
       for (i in enabled) {
         if (enabled.hasOwnProperty(i)) {
-          var val = Drupal.personalize.visitor_context_read(i);
+          var val = Drupal.personalize.visitor_context_read(i, context);
           if (val !== null) {
             context_values[i] = val;
           }

--- a/modules/personalize_url_context/plugins/visitor_context/QuerystringContext.inc
+++ b/modules/personalize_url_context/plugins/visitor_context/QuerystringContext.inc
@@ -30,7 +30,15 @@ class QuerystringContext extends PersonalizeContextBase {
     // Add the referrer URL context. This will get lumped into the
     // "Miscellaneous" group.
     $options['referrer_url'] = array(
-      'name' => t('Referrer URL')
+      'name' => t('Referrer URL'),
+      'cache_type' => 'session'
+    );
+
+    // Add the original URL referrer to the misc. group.
+    $options['original_referrer_url'] = array(
+      'name' => t('Original referrer URL'),
+      'cache_type' => 'local',
+      'cache_expiration' => 'none',
     );
 
     return $options;

--- a/modules/personalize_url_context/plugins/visitor_context/QuerystringContext.inc
+++ b/modules/personalize_url_context/plugins/visitor_context/QuerystringContext.inc
@@ -23,7 +23,8 @@ class QuerystringContext extends PersonalizeContextBase {
     foreach ($params as $name) {
       $options[$name] = array(
         'name' => $name,
-        'group' => 'Querystring Params'
+        'group' => 'Querystring Params',
+        'cache_type' => 'session',
       );
     }
     // Add the referrer URL context. This will get lumped into the

--- a/modules/personalize_url_context/tests/personalize_url_context.test
+++ b/modules/personalize_url_context/tests/personalize_url_context.test
@@ -110,8 +110,8 @@ class PersonalizeUrlContextTest extends DrupalWebTestCase {
     );
     $agent->status = PERSONALIZE_STATUS_RUNNING;
     personalize_agent_save($agent);
-    $agent = personalize_agent_load('test-agent');
 
+    $this->resetAll();
     // Load a page and verify cache settings.
     $this->drupalGet('');
     $settings = $this->drupalGetSettings();

--- a/modules/personalize_url_context/tests/personalize_url_context.test
+++ b/modules/personalize_url_context/tests/personalize_url_context.test
@@ -62,10 +62,17 @@ class PersonalizeUrlContextTest extends DrupalWebTestCase {
       $expected_param_names[$name] = array(
         'name' => $name,
         'group' => 'Querystring Params',
+        'cache_type' => 'session',
       );
     }
     $expected_param_names['referrer_url'] = array(
-      'name' => t('Referrer URL')
+      'name' => t('Referrer URL'),
+      'cache_type' => 'session',
+    );
+    $expected_param_names['original_referrer_url'] = array(
+      'name' => t('Original referrer URL'),
+      'cache_type' => 'local',
+      'cache_expiration' => 'none',
     );
     $this->assertEqual($expected_param_names, $options);
 
@@ -85,5 +92,31 @@ class PersonalizeUrlContextTest extends DrupalWebTestCase {
     );
     $possible_values = $context_plugin->getPossibleValues();
     $this->assertEqual($expected_values, $possible_values);
+  }
+
+  /**
+   * Test that url context options for a visitor contexts are passed to JS.
+   */
+  function testCacheExpiration() {
+    $admin_user = $this->drupalCreateUser(array('access administration pages', 'manage personalized content'));
+    $this->drupalLogin($admin_user);
+
+    // Add visitor context to a test agent.
+    $agent = personalize_agent_load('test-agent');
+    $agent->data['visitor_context']['querystring_context'] = array(
+      'utm_campaign' => 'utm_campaign',
+      'referrer_url' => 'referrer_url',
+      'original_referrer_url' => 'original_referrer_url',
+    );
+    $agent->status = PERSONALIZE_STATUS_RUNNING;
+    personalize_agent_save($agent);
+    $agent = personalize_agent_load('test-agent');
+
+    // Load a page and verify cache settings.
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual('session', $settings['personalize']['cacheExpiration']['visitor_context:utm_campaign']);
+    $this->assertEqual('session', $settings['personalize']['cacheExpiration']['visitor_context:referrer_url']);
+    $this->assertEqual('none', $settings['personalize']['cacheExpiration']['visitor_context:original_referrer_url']);
   }
 }

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -72,7 +72,7 @@ function personalize_admin_form_validate($form, &$form_state) {
 function personalize_admin_form_submit($form, &$form_state) {
   // Clear the visitor context cache settings if the allowed contexts changed.
   // This submit callback is called BEFORE the system_settings_form callback.
-  if ($form_state['values']['personalize_visitor_context_disabled'] != variable_get('personalize_visitor_context_disabled')) {
+  if (isset($form_state['values']['personalize_visitor_context_disabled']) && $form_state['values']['personalize_visitor_context_disabled'] != variable_get('personalize_visitor_context_disabled')) {
     personalize_visitor_context_expiration_clear();
   }
 }

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -14,7 +14,7 @@ function personalize_admin_form($form, &$form_state) {
     '#title' => t('Cache settings'),
     '#tree' => FALSE,
   );
-  $form['cache']['personalize_cache_decision_storage'] = array(
+  $form['cache']['personalize_local_caching_storage'] = array(
     '#type' => 'select',
     '#title' => t('Campaign cache storage'),
     '#description' => t("For campaigns that cache decisions, select session to clear the cache at the end of the visitor's session or persist to save for a specific amount of time across all sessions."),
@@ -22,18 +22,18 @@ function personalize_admin_form($form, &$form_state) {
       'session' => t('Session'),
       'local' => t('Persist'),
     ),
-    '#default_value' => variable_get('personalize_cache_decision_storage', 'session'),
+    '#default_value' => variable_get('personalize_local_caching_storage', 'session'),
   );
-  $form['cache']['personalize_cache_decision_expiration'] = array(
+  $form['cache']['personalize_local_caching_expiration'] = array(
     '#type' => 'textfield',
     '#title' => t('Campaign cache expiration'),
     '#description' => t("For campaigns that cache decisions, the amount of time to keep decisions in the visitor's local cache."),
-    '#default_value' => variable_get('personalize_cache_decision_expiration', 30),
+    '#default_value' => variable_get('personalize_local_caching_expiration', 30),
     '#field_suffix' => t('minutes'),
     '#size' => 5,
     '#states' => array(
       'visible' => array(
-        ':input[name="personalize_cache_decision_storage"]' => array('value' => 'local'),
+        ':input[name="personalize_local_caching_storage"]' => array('value' => 'local'),
       ),
     ),
   );

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -9,18 +9,36 @@
  * Admin form for configuring personalization backends.
  */
 function personalize_admin_form($form, &$form_state) {
-  $form['personalize_local_caching_expiration'] = array(
+  $form['cache'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Cache settings'),
+    '#tree' => FALSE,
+  );
+  $form['cache']['personalize_cache_decision_expiration'] = array(
     '#type' => 'textfield',
-    '#title' => t('LocalStorage expiration'),
-    '#description' => t('For agents configured to cache decisions in local storage, the amount of time they should be cached for.'),
-    '#default_value' => variable_get('personalize_local_caching_expiration', 30),
+    '#title' => t('Decision agent cache expiration'),
+    '#description' => t('For agents configured to cache decisions in local storage, the amount of time they should be cached for.  Enter 0 to cache only for user session'),
+    '#default_value' => variable_get('personalize_cache_decision_expiration', 30),
     '#field_suffix' => t('minutes'),
     '#size' => 5,
   );
-  $form['personalize_cache_visitor_context'] = array(
+  $form['cache']['personalize_cache_visitor_context'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Cache visitor context in localStorage if available'),
+    '#title' => t('Cache visitor context in local storage, if available.'),
     '#default_value' => variable_get('personalize_cache_visitor_context', FALSE),
+  );
+  $form['cache']['personalize_cache_visitor_context_expiration'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Visitor context cache expiration'),
+    '#description' => t('The amount of time to cache visitor context.  Enter 0 to cache only for the user session.'),
+    '#default_value' => variable_get('personalize_cache_visitor_context_expiration', 30),
+    '#field_suffix' => t('minutes'),
+    '#size' => 5,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="personalize_cache_visitor_context"]' => array('checked' => TRUE),
+      ),
+    ),
   );
   $form['personalize_use_admin_mode'] = array(
     '#type' => 'checkbox',

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -14,29 +14,26 @@ function personalize_admin_form($form, &$form_state) {
     '#title' => t('Cache settings'),
     '#tree' => FALSE,
   );
+  $form['cache']['personalize_cache_decision_storage'] = array(
+    '#type' => 'select',
+    '#title' => t('Campaign cache storage'),
+    '#description' => t("For campaigns that cache decisions, select session to clear the cache at the end of the visitor's session or persist to save for a specific amount of time across all sessions."),
+    '#options' => array(
+      'session' => t('Session'),
+      'local' => t('Persist'),
+    ),
+    '#default_value' => variable_get('personalize_cache_decision_storage', 'session'),
+  );
   $form['cache']['personalize_cache_decision_expiration'] = array(
     '#type' => 'textfield',
-    '#title' => t('Decision agent cache expiration'),
-    '#description' => t('For agents configured to cache decisions in local storage, the amount of time they should be cached for.  Enter 0 to cache only for user session'),
-    '#default_value' => variable_get('personalize_cache_decision_expiration', 0),
-    '#field_suffix' => t('minutes'),
-    '#size' => 5,
-  );
-  $form['cache']['personalize_cache_visitor_context'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Cache visitor context in local storage, if available.'),
-    '#default_value' => variable_get('personalize_cache_visitor_context', FALSE),
-  );
-  $form['cache']['personalize_cache_visitor_context_expiration'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Visitor context cache expiration'),
-    '#description' => t('The amount of time to cache visitor context.  Enter 0 to cache only for the user session.'),
-    '#default_value' => variable_get('personalize_cache_visitor_context_expiration', 30),
+    '#title' => t('Campaign cache expiration'),
+    '#description' => t("For campaigns that cache decisions, the amount of time to keep decisions in the visitor's local cache."),
+    '#default_value' => variable_get('personalize_cache_decision_expiration', 30),
     '#field_suffix' => t('minutes'),
     '#size' => 5,
     '#states' => array(
       'visible' => array(
-        ':input[name="personalize_cache_visitor_context"]' => array('checked' => TRUE),
+        ':input[name="personalize_cache_decision_storage"]' => array('value' => 'local'),
       ),
     ),
   );

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -18,7 +18,7 @@ function personalize_admin_form($form, &$form_state) {
     '#type' => 'textfield',
     '#title' => t('Decision agent cache expiration'),
     '#description' => t('For agents configured to cache decisions in local storage, the amount of time they should be cached for.  Enter 0 to cache only for user session'),
-    '#default_value' => variable_get('personalize_cache_decision_expiration', 30),
+    '#default_value' => variable_get('personalize_cache_decision_expiration', 0),
     '#field_suffix' => t('minutes'),
     '#size' => 5,
   );

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -48,6 +48,10 @@ function personalize_admin_form($form, &$form_state) {
   $form['personalize_visitor_context_disabled'] = personalize_admin_build_visitor_context_select($settings, FALSE);
   $form['personalize_visitor_context_disabled']['#title'] = t('Disallowed visitor context items');
   $form['personalize_visitor_context_disabled']['#description'] = t('Select which visitor context items should never show up when configuring visitor context for campaigns.');
+
+  // Add our own submit handler to run BEFORE settings form handler.
+  $form['#submit'][] = 'personalize_admin_form_submit';
+
   return system_settings_form($form);
 }
 
@@ -59,6 +63,17 @@ function personalize_admin_form_validate($form, &$form_state) {
   // settings need to be shuffled around.
   if (isset($form_state['values']['personalize_visitor_context_disabled'])) {
     $form_state['values']['personalize_visitor_context_disabled'] = personalize_admin_convert_visitor_context_form_values($form_state['values']['personalize_visitor_context_disabled']);
+  }
+}
+
+/**
+ * Submit callback for settings form.
+ */
+function personalize_admin_form_submit($form, &$form_state) {
+  // Clear the visitor context cache settings if the allowed contexts changed.
+  // This submit callback is called BEFORE the system_settings_form callback.
+  if ($form_state['values']['personalize_visitor_context_disabled'] != variable_get('personalize_visitor_context_disabled')) {
+    personalize_visitor_context_expiration_clear();
   }
 }
 

--- a/personalize.install
+++ b/personalize.install
@@ -266,7 +266,9 @@ function personalize_disable() {
  */
 function personalize_uninstall() {
   // Delete variables.
-  variable_del('personalize_local_caching_expiration');
+  variable_del('personalize_cache_decision_expiration');
+  variable_del('personalize_cache_visitor_context');
+  variable_del('personalize_cache_visitor_context_expiration');
   variable_del('personalize_use_admin_mode');
   variable_del('personalize_visitor_context_disabled');
 }

--- a/personalize.install
+++ b/personalize.install
@@ -267,8 +267,7 @@ function personalize_disable() {
 function personalize_uninstall() {
   // Delete variables.
   variable_del('personalize_cache_decision_expiration');
-  variable_del('personalize_cache_visitor_context');
-  variable_del('personalize_cache_visitor_context_expiration');
+  variable_del('personalize_cache_decision_storage');
   variable_del('personalize_use_admin_mode');
   variable_del('personalize_visitor_context_disabled');
 }

--- a/personalize.install
+++ b/personalize.install
@@ -266,8 +266,8 @@ function personalize_disable() {
  */
 function personalize_uninstall() {
   // Delete variables.
-  variable_del('personalize_cache_decision_expiration');
-  variable_del('personalize_cache_decision_storage');
+  variable_del('personalize_local_caching_expiration');
+  variable_del('personalize_local_caching_storage');
   variable_del('personalize_use_admin_mode');
   variable_del('personalize_visitor_context_disabled');
 }

--- a/personalize.module
+++ b/personalize.module
@@ -231,10 +231,17 @@ function personalize_page_build(&$page) {
   // Add the necessary JavaScript for personalization.
   $path = drupal_get_path('module', 'personalize');
   $settings = array(
-    'cacheExpiration' => variable_get('personalize_local_caching_expiration', 30),
     'cacheVisitorContext' => variable_get('personalize_cache_visitor_context', FALSE),
     'optionPreselectParam' => PERSONALIZE_PRESELECTION_PARAM,
   );
+  // cacheExpiration keys should match web storage bucket names.
+  // @see js/personalize.js
+  $settings['cacheExpiration'] = array(
+    'decisions' => variable_get('personalize_cache_decision_expiration', 30),
+  );
+  if ($settings['cacheVisitorContext']) {
+    $settings['cacheExpiration']['visitor_context'] = variable_get('personalize_cache_visitor_context_expiration', 30);
+  }
 
   $options = array(
     'scope' => 'footer',

--- a/personalize.module
+++ b/personalize.module
@@ -236,7 +236,7 @@ function personalize_page_build(&$page) {
   // cacheExpiration keys should match web storage bucket names.
   // @see js/personalize.js
   $settings['cacheExpiration'] = array(
-    'decisions' => variable_get('personalize_cache_decision_storage', 'session') == 'session' ? 'session' : variable_get('personalize_cache_decision_expiration', 30),
+    'decisions' => variable_get('personalize_local_caching_storage', 'session') == 'session' ? 'session' : variable_get('personalize_local_caching_expiration', 30),
   );
   // Get the cache settings for visitor contexts.
   // Limit this to only those contexts for currently running campaigns.

--- a/personalize.module
+++ b/personalize.module
@@ -231,18 +231,30 @@ function personalize_page_build(&$page) {
   // Add the necessary JavaScript for personalization.
   $path = drupal_get_path('module', 'personalize');
   $settings = array(
-    'cacheVisitorContext' => variable_get('personalize_cache_visitor_context', FALSE),
     'optionPreselectParam' => PERSONALIZE_PRESELECTION_PARAM,
   );
   // cacheExpiration keys should match web storage bucket names.
   // @see js/personalize.js
   $settings['cacheExpiration'] = array(
-    'decisions' => variable_get('personalize_cache_decision_expiration', 0),
+    'decisions' => variable_get('personalize_cache_decision_storage', 'session') == 'session' ? 'session' : variable_get('personalize_cache_decision_expiration', 30),
   );
-  if ($settings['cacheVisitorContext']) {
-    // If visitor contexts have different expirations, set the bucket expiration
-    // values for each separately here.
-    $settings['cacheExpiration']['visitor_context'] = variable_get('personalize_cache_visitor_context_expiration', 30);
+  // Get the cache settings for visitor contexts.
+  // NOTE: This is not limited to those of the active campaign as to prevent
+  // additional looping through contexts that could be applied to each decision.
+  $contexts = personalize_get_visitor_contexts();
+  foreach ($contexts as $plugin_name => $plugin_info) {
+    if ($class = ctools_plugin_load_class('personalize', 'visitor_context', $plugin_name, 'handler')) {
+      $context_options = call_user_func(array($class, 'getOptions'));
+      $disallowed = variable_get('personalize_visitor_context_disabled', array());
+      foreach ($context_options as $code => $info) {
+        if (isset($disallowed[$plugin_name][$code])) {
+          continue;
+        }
+        if (!empty($info['cache_type']) && $info['cache_type'] != 'none') {
+          $settings['cacheExpiration']['visitor_context:' . $code] = $info['cache_type'] == 'session' ? 'session' : $info['cache_expiration'];
+        }
+      }
+    }
   }
 
   $options = array(

--- a/personalize.module
+++ b/personalize.module
@@ -239,15 +239,20 @@ function personalize_page_build(&$page) {
     'decisions' => variable_get('personalize_cache_decision_storage', 'session') == 'session' ? 'session' : variable_get('personalize_cache_decision_expiration', 30),
   );
   // Get the cache settings for visitor contexts.
-  // NOTE: This is not limited to those of the active campaign as to prevent
-  // additional looping through contexts that could be applied to each decision.
-  $contexts = personalize_get_visitor_contexts();
-  foreach ($contexts as $plugin_name => $plugin_info) {
+  // Limit this to only those contexts for currently running campaigns.
+  $current_campaigns = personalize_agent_load_multiple(array(), array('status' => PERSONALIZE_STATUS_RUNNING));
+  $current_campaign_contexts = array();
+  // Get the visitor context for each of the currently running campaigns.
+  foreach ($current_campaigns as $campaign) {
+    $current_campaign_contexts = array_merge_recursive($current_campaign_contexts, $campaign->data['visitor_context']);
+  }
+  // Now loop over those contexts and add the option cache expiration data.
+  $disallowed = variable_get('personalize_visitor_context_disabled', array());
+  foreach ($current_campaign_contexts as $plugin_name => $selected_contexts) {
     if ($class = ctools_plugin_load_class('personalize', 'visitor_context', $plugin_name, 'handler')) {
       $context_options = call_user_func(array($class, 'getOptions'));
-      $disallowed = variable_get('personalize_visitor_context_disabled', array());
       foreach ($context_options as $code => $info) {
-        if (isset($disallowed[$plugin_name][$code])) {
+        if (isset($disallowed[$plugin_name][$code]) || !in_array($code, $selected_contexts)) {
           continue;
         }
         if (!empty($info['cache_type']) && $info['cache_type'] != 'none') {

--- a/personalize.module
+++ b/personalize.module
@@ -13,6 +13,7 @@ define('PERSONALIZE_NEW_AGENT_FORM_VALUE', '__new__');
 define('PERSONALIZE_MACHINE_NAME_REPLACE_PATTERN', '[^a-z0-9-]+');
 define('PERSONALIZE_MACHINE_NAME_MAXLENGTH', 64);
 define('PERSONALIZE_TARGETING_OP_SEPARATOR', '-');
+define('PERSONALIZE_CONTEXT_EXPIRATION_CACHE', 'personalize:visitor_context:expiration');
 
 /**
  * Define constants for campaign status values.
@@ -233,36 +234,13 @@ function personalize_page_build(&$page) {
   $settings = array(
     'optionPreselectParam' => PERSONALIZE_PRESELECTION_PARAM,
   );
+
   // cacheExpiration keys should match web storage bucket names.
   // @see js/personalize.js
-  $settings['cacheExpiration'] = array(
-    'decisions' => variable_get('personalize_local_caching_storage', 'session') == 'session' ? 'session' : variable_get('personalize_local_caching_expiration', 30),
-  );
   // Get the cache settings for visitor contexts.
-  // Limit this to only those contexts for currently running campaigns.
-  $current_campaigns = personalize_agent_load_multiple(array(), array('status' => PERSONALIZE_STATUS_RUNNING));
-  $current_campaign_contexts = array();
-  // Get the visitor context for each of the currently running campaigns.
-  foreach ($current_campaigns as $campaign) {
-    if (!empty($campaign->data['visitor_context'])) {
-      $current_campaign_contexts = array_merge_recursive($current_campaign_contexts, $campaign->data['visitor_context']);
-    }
-  }
-  // Now loop over those contexts and add the option cache expiration data.
-  $disallowed = variable_get('personalize_visitor_context_disabled', array());
-  foreach ($current_campaign_contexts as $plugin_name => $selected_contexts) {
-    if ($class = ctools_plugin_load_class('personalize', 'visitor_context', $plugin_name, 'handler')) {
-      $context_options = call_user_func(array($class, 'getOptions'));
-      foreach ($context_options as $code => $info) {
-        if (isset($disallowed[$plugin_name][$code]) || !array_key_exists($code, $selected_contexts)) {
-          continue;
-        }
-        if (!empty($info['cache_type'])) {
-          $settings['cacheExpiration']['visitor_context:' . $code] = $info['cache_type'] == 'session' ? 'session' : $info['cache_expiration'];
-        }
-      }
-    }
-  }
+  $settings['cacheExpiration'] = personalize_visitor_context_expiration_load();
+  // Add in the decision caching expiration settings.
+  $settings['cacheExpiration']['decisions'] = variable_get('personalize_local_caching_storage', 'session') == 'session' ? 'session' : variable_get('personalize_local_caching_expiration', 30);
 
   $options = array(
     'scope' => 'footer',
@@ -725,6 +703,9 @@ function personalize_agent_set_status($agent_name, $status) {
 
   // Clear the agent cache for this agent.
   personalize_agent_load($agent_name, TRUE);
+
+  // Clear the visitor context cache settings for running campaigns.
+  personalize_visitor_context_expiration_clear();
 
   // Allow modules to act on the fact that this agent's status has changed.
   module_invoke_all('personalize_agent_update_status', $agent_name, $old_status, $status);
@@ -2080,7 +2061,7 @@ function personalize_mvt_load_all_by_agent($agent_name) {
 
 /**
  * =======================================================================
- *  U S E R  C O N T E X T  R E L A T E D
+ *  V I S I T O R  C O N T E X T  R E L A T E D
  * =======================================================================
  */
 
@@ -2098,6 +2079,59 @@ function personalize_personalize_visitor_context() {
     ),
   );
   return $info;
+}
+
+/**
+ * Load the visitor context cache expiration settings.
+ *
+ * These cache expiration settings are cached as they would only change when
+ * either 1) the campaign status changes; or 2) the disallowed contexts change.
+ *
+ * @return array
+ *   An array of visitor context cache expiration settings with keys for each
+ *   option within a context.  Suitable for use with JavaScript.
+ *
+ * @see personalize.js
+ */
+function personalize_visitor_context_expiration_load() {
+  // Load from the cache if available.
+  if ($expiration = cache_get(PERSONALIZE_CONTEXT_EXPIRATION_CACHE)) {
+    return $expiration->data;
+  }
+  // Get all currently running campaigns
+  $current_campaigns = personalize_agent_load_multiple(array(), array('status' => PERSONALIZE_STATUS_RUNNING));
+  $current_campaign_contexts = array();
+  // Get the visitor context for each of the currently running campaigns.
+  foreach ($current_campaigns as $campaign) {
+    if (!empty($campaign->data['visitor_context'])) {
+      $current_campaign_contexts = array_merge_recursive($current_campaign_contexts, $campaign->data['visitor_context']);
+    }
+  }
+  // Now loop over those contexts and add the option cache expiration data.
+  $disallowed = variable_get('personalize_visitor_context_disabled', array());
+  foreach ($current_campaign_contexts as $plugin_name => $selected_contexts) {
+    if ($class = ctools_plugin_load_class('personalize', 'visitor_context', $plugin_name, 'handler')) {
+      $context_options = call_user_func(array($class, 'getOptions'));
+      foreach ($context_options as $code => $info) {
+        if (isset($disallowed[$plugin_name][$code]) || !array_key_exists($code, $selected_contexts)) {
+          continue;
+        }
+        if (!empty($info['cache_type'])) {
+          $expiration['visitor_context:' . $code] = $info['cache_type'] == 'session' ? 'session' : $info['cache_expiration'];
+        }
+      }
+    }
+  }
+  // Set in the cache for easier future retrieval.
+  cache_set(PERSONALIZE_CONTEXT_EXPIRATION_CACHE, $expiration);
+  return $expiration;
+}
+
+/**
+ * Clear the visitor context expiration cache settings.
+ */
+function personalize_visitor_context_expiration_clear() {
+  cache_clear_all(PERSONALIZE_CONTEXT_EXPIRATION_CACHE, 'cache');
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -2117,7 +2117,7 @@ function personalize_visitor_context_expiration_load() {
           continue;
         }
         if (!empty($info['cache_type'])) {
-          $expiration['visitor_context:' . $code] = $info['cache_type'] == 'session' ? 'session' : $info['cache_expiration'];
+          $expiration['visitor_context:' . $plugin_name . ':' . $code] = $info['cache_type'] == 'session' ? 'session' : $info['cache_expiration'];
         }
       }
     }

--- a/personalize.module
+++ b/personalize.module
@@ -244,7 +244,9 @@ function personalize_page_build(&$page) {
   $current_campaign_contexts = array();
   // Get the visitor context for each of the currently running campaigns.
   foreach ($current_campaigns as $campaign) {
-    $current_campaign_contexts = array_merge_recursive($current_campaign_contexts, $campaign->data['visitor_context']);
+    if (!empty($campaign->data['visitor_context'])) {
+      $current_campaign_contexts = array_merge_recursive($current_campaign_contexts, $campaign->data['visitor_context']);
+    }
   }
   // Now loop over those contexts and add the option cache expiration data.
   $disallowed = variable_get('personalize_visitor_context_disabled', array());

--- a/personalize.module
+++ b/personalize.module
@@ -254,10 +254,10 @@ function personalize_page_build(&$page) {
     if ($class = ctools_plugin_load_class('personalize', 'visitor_context', $plugin_name, 'handler')) {
       $context_options = call_user_func(array($class, 'getOptions'));
       foreach ($context_options as $code => $info) {
-        if (isset($disallowed[$plugin_name][$code]) || !in_array($code, $selected_contexts)) {
+        if (isset($disallowed[$plugin_name][$code]) || !array_key_exists($code, $selected_contexts)) {
           continue;
         }
-        if (!empty($info['cache_type']) && $info['cache_type'] != 'none') {
+        if (!empty($info['cache_type'])) {
           $settings['cacheExpiration']['visitor_context:' . $code] = $info['cache_type'] == 'session' ? 'session' : $info['cache_expiration'];
         }
       }

--- a/personalize.module
+++ b/personalize.module
@@ -237,9 +237,11 @@ function personalize_page_build(&$page) {
   // cacheExpiration keys should match web storage bucket names.
   // @see js/personalize.js
   $settings['cacheExpiration'] = array(
-    'decisions' => variable_get('personalize_cache_decision_expiration', 30),
+    'decisions' => variable_get('personalize_cache_decision_expiration', 0),
   );
   if ($settings['cacheVisitorContext']) {
+    // If visitor contexts have different expirations, set the bucket expiration
+    // values for each separately here.
     $settings['cacheExpiration']['visitor_context'] = variable_get('personalize_cache_visitor_context_expiration', 30);
   }
 

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1366,8 +1366,8 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
     $this->drupalLogin($admin_user);
     // Set the local storage expiration to 60
     $edit = array(
-      'personalize_cache_decision_expiration' => 60,
-      'personalize_cache_decision_storage' => 'local',
+      'personalize_local_caching_expiration' => 60,
+      'personalize_local_caching_storage' => 'local',
     );
     $this->drupalPost('admin/config/content/personalize', $edit, $this->getButton('config'));
     $this->drupalGet('');
@@ -1377,7 +1377,7 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
 
     // Set the local storage to session and leave the expiration to ensure the
     // expiration changes based on storage change only.
-    $edit['personalize_cache_decision_storage'] = 'session';
+    $edit['personalize_local_caching_storage'] = 'session';
     $this->drupalPost('admin/config/content/personalize', $edit, $this->getButton('config'));
     $this->drupalGet('');
     // Assert the correct setting is in the js.

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -190,7 +190,7 @@ class PersonalizeTest extends PersonalizeBaseTest {
   }
 
   function setUp() {
-    parent::setUp(array('ctools', 'personalize', 'personalize_test', 'personalize_blocks'));
+    parent::setUp(array('ctools', 'personalize', 'personalize_test', 'personalize_blocks', 'personalize_test_visitor_context'));
   }
 
   function testPermissions() {
@@ -675,28 +675,29 @@ class PersonalizeTest extends PersonalizeBaseTest {
 
     // Verify the cache settings are in the Drupal settings.
     $settings = $this->drupalGetSettings();
-    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_session'], 'session');
-    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_30'], '30');
-    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_none'], 'none');
-    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_nocache']));
+    debug($settings['personalize']['cacheExpiration']);
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_session'], 'session');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_local_30'], '30');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_local_none'], 'none');
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_nocache']));
 
     // Pause the campaign and verify that the settings are no longer there.
     personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_PAUSED);
     $this->drupalGet('');
     $settings = $this->drupalGetSettings();
-    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_session']));
-    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_local_30']));
-    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_local_none']));
-    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_nocache']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_session']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_local_30']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_local_none']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_nocache']));
 
     // Restart the agent and verify that they come back.
     personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_RUNNING);
     $this->drupalGet('');
     $settings = $this->drupalGetSettings();
-    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_session'], 'session');
-    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_30'], '30');
-    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_none'], 'none');
-    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_nocache']));
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_session'], 'session');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_local_30'], '30');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_local_none'], 'none');
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:personalize_test_visitor_context:test_nocache']));
 
     // Remove one of the contexts from those allowed and verify it is removed.
     $edit = array(

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1365,11 +1365,11 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
     $admin_user = $this->drupalCreateUser(array('administer personalize configuration', 'access administration pages'));
     $this->drupalLogin($admin_user);
     // Set localStorage expiration to 60
-    $this->drupalPost('admin/config/content/personalize', array( 'personalize_local_caching_expiration' => 60), $this->getButton('config'));
+    $this->drupalPost('admin/config/content/personalize', array( 'personalize_cache_decision_expiration' => 60), $this->getButton('config'));
     $this->drupalGet('');
     // Assert the correct setting is in the js.
     $settings = $this->drupalGetSettings();
-    $this->assertEqual(60, $settings['personalize']['cacheExpiration']);
+    $this->assertEqual(60, $settings['personalize']['cacheExpiration']['decisions']);
 
     // Set localStorage for visitor context to false.
     $this->drupalPost('admin/config/content/personalize', array('personalize_cache_visitor_context' => FALSE), $this->getButton('config'));
@@ -1377,12 +1377,14 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
     // Assert the correct setting is in the js.
     $settings = $this->drupalGetSettings();
     $this->assertFalse($settings['personalize']['cacheVisitorContext']);
+    $this->assertTrue(empty($settings['personalize']['cacheExpiration']['visitor_context']));
     // Set localStorage for visitor context to true
-    $this->drupalPost('admin/config/content/personalize', array('personalize_cache_visitor_context' => TRUE), $this->getButton('config'));
+    $this->drupalPost('admin/config/content/personalize', array('personalize_cache_visitor_context' => TRUE, 'personalize_cache_visitor_context_expiration' => 60), $this->getButton('config'));
     $this->drupalGet('');
     // Assert the correct setting is in the js.
     $settings = $this->drupalGetSettings();
     $this->assertTrue($settings['personalize']['cacheVisitorContext']);
+    $this->assertEqual(60, $settings['personalize']['cacheExpiration']['visitor_context']);
   }
 
   /**

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1364,27 +1364,25 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
   function testConfigurationSettings() {
     $admin_user = $this->drupalCreateUser(array('administer personalize configuration', 'access administration pages'));
     $this->drupalLogin($admin_user);
-    // Set localStorage expiration to 60
-    $this->drupalPost('admin/config/content/personalize', array( 'personalize_cache_decision_expiration' => 60), $this->getButton('config'));
+    // Set the local storage expiration to 60
+    $edit = array(
+      'personalize_cache_decision_expiration' => 60,
+      'personalize_cache_decision_storage' => 'local',
+    );
+    $this->drupalPost('admin/config/content/personalize', $edit, $this->getButton('config'));
     $this->drupalGet('');
     // Assert the correct setting is in the js.
     $settings = $this->drupalGetSettings();
     $this->assertEqual(60, $settings['personalize']['cacheExpiration']['decisions']);
 
-    // Set localStorage for visitor context to false.
-    $this->drupalPost('admin/config/content/personalize', array('personalize_cache_visitor_context' => FALSE), $this->getButton('config'));
+    // Set the local storage to session and leave the expiration to ensure the
+    // expiration changes based on storage change only.
+    $edit['personalize_cache_decision_storage'] = 'session';
+    $this->drupalPost('admin/config/content/personalize', $edit, $this->getButton('config'));
     $this->drupalGet('');
     // Assert the correct setting is in the js.
     $settings = $this->drupalGetSettings();
-    $this->assertFalse($settings['personalize']['cacheVisitorContext']);
-    $this->assertTrue(empty($settings['personalize']['cacheExpiration']['visitor_context']));
-    // Set localStorage for visitor context to true
-    $this->drupalPost('admin/config/content/personalize', array('personalize_cache_visitor_context' => TRUE, 'personalize_cache_visitor_context_expiration' => 60), $this->getButton('config'));
-    $this->drupalGet('');
-    // Assert the correct setting is in the js.
-    $settings = $this->drupalGetSettings();
-    $this->assertTrue($settings['personalize']['cacheVisitorContext']);
-    $this->assertEqual(60, $settings['personalize']['cacheExpiration']['visitor_context']);
+    $this->assertEqual('session', $settings['personalize']['cacheExpiration']['decisions']);
   }
 
   /**

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -651,6 +651,64 @@ class PersonalizeTest extends PersonalizeBaseTest {
   }
 
   /**
+   * Tests that the visitor context expiration cache is properly set and
+   * cleared as needed.
+   */
+  function testVisitorContextExpirationCache() {
+    // Create an agent.
+    $admin_user = $this->drupalCreateUser(array('access administration pages', 'manage personalized content', 'administer blocks', 'administer personalize configuration'));
+    $this->drupalLogin($admin_user);
+
+    $agent = personalize_agent_load('test-agent');
+    $agent->data['visitor_context']['personalize_test_visitor_context'] = array(
+      'test_session' => 'test_session',
+      'test_local_30' => 'test_local_30',
+      'test_local_none' => 'test_local_none',
+      'test_nocache' => 'test_nocache',
+    );
+    $agent->status = PERSONALIZE_STATUS_RUNNING;
+    personalize_agent_save($agent);
+    $this->resetAll();
+
+    // Load a page and verify cache settings.
+    $this->drupalGet('');
+
+    // Verify the cache settings are in the Drupal settings.
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_session'], 'session');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_30'], '30');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_none'], 'none');
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_nocache']));
+
+    // Pause the campaign and verify that the settings are no longer there.
+    personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_PAUSED);
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_session']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_local_30']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_local_none']));
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_nocache']));
+
+    // Restart the agent and verify that they come back.
+    personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_RUNNING);
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_session'], 'session');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_30'], '30');
+    $this->assertEqual($settings['personalize']['cacheExpiration']['visitor_context:test_local_none'], 'none');
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_nocache']));
+
+    // Remove one of the contexts from those allowed and verify it is removed.
+    $edit = array(
+      'personalize_visitor_context_disabled[]' => 'personalize_test_visitor_context__test_session',
+    );
+    $this->drupalPost('admin/config/content/personalize', $edit, $this->getButton('config'));
+    $this->drupalGet('');
+    $settings = $this->drupalGetSettings();
+    $this->assertFalse(isset($settings['personalize']['cacheExpiration']['visitor_context:test_session']));
+  }
+
+  /**
    * Tests the ajax callback executor available for personalized blocks.
    *
    * This test also tests the setting of the executor setting.

--- a/tests/personalize_test_visitor_context/personalize_test_visitor_context.info
+++ b/tests/personalize_test_visitor_context/personalize_test_visitor_context.info
@@ -1,0 +1,6 @@
+name = Personalize Visitor Text Context Test
+description = Provides a visitor context plugin for testing purposes.
+dependencies[] = personalize
+package = Testing
+core = 7.x
+hidden = TRUE

--- a/tests/personalize_test_visitor_context/personalize_test_visitor_context.module
+++ b/tests/personalize_test_visitor_context/personalize_test_visitor_context.module
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file personalize_url_context.module
+ * Provides a visitor context plugin for querystring params.
+ */
+
+/**
+ * Implements hook_personalize_visitor_contexts().
+ */
+function personalize_test_visitor_context_personalize_visitor_context() {
+  $info = array();
+  $path = drupal_get_path('module', 'personalize_test_visitor_context') . '/plugins';
+  $info['personalize_test_visitor_context'] = array(
+    'path' => $path . '/visitor_context',
+    'handler' => array(
+      'file' => 'TestVisitorContext.inc',
+      'class' => 'TestVisitorContext',
+    ),
+  );
+  return $info;
+}
+
+/**
+ * Implements hook_ctools_plugin_api().
+ */
+function personalize_test_visitor_context_ctools_plugin_api($owner, $api) {
+  if ($owner == 'personalize' && $api == 'personalize') {
+    return array('version' => 1);
+  }
+}

--- a/tests/personalize_test_visitor_context/personalize_test_visitor_context.module
+++ b/tests/personalize_test_visitor_context/personalize_test_visitor_context.module
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implements hook_personalize_visitor_contexts().
+ * Implements hook_personalize_visitor_context().
  */
 function personalize_test_visitor_context_personalize_visitor_context() {
   $info = array();

--- a/tests/personalize_test_visitor_context/plugins/visitor_context/TestVisitorContext.inc
+++ b/tests/personalize_test_visitor_context/plugins/visitor_context/TestVisitorContext.inc
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @file
+ * Provides a visitor context plugin for querystring params
+
+ */
+
+class TestVisitorContext extends PersonalizeContextBase {
+
+  /**
+   * Implements PersonalizeContextInterface::create().
+   */
+  public static function create(PersonalizeAgentInterface $agent, $selected_context) {
+    return new self($agent, $selected_context);
+  }
+
+  /**
+   * Implements PersonalizeContextInterface::getOptions().
+   */
+  public static function getOptions() {
+    $options = array();
+    $options['test_session'] = array(
+      'name' => 'Test Session Option',
+      'group' => 'Test Visitor Context',
+      'cache_type' => 'session',
+    );
+    $options['test_local_30'] = array(
+      'name' => 'Test Local Option 30 min',
+      'group' => 'Test Visitor Context',
+      'cache_type' => 'local',
+      'cache_expiration' => 30,
+    );
+    $options['test_local_none'] = array(
+      'name' => 'Test Local Option No Expire',
+      'group' => 'Test Visitor Context',
+      'cache_type' => 'local',
+      'cache_expiration' => 'none',
+    );
+    $options['test_nocache'] = array(
+      'name' => 'Test No Cache',
+      'group' => 'Test Visitor Context',
+    );
+    return $options;
+  }
+
+  /**
+   * Implements PersonalizeAgentInterface::getPossibleValues().
+   */
+  public function getPossibleValues() {
+    $options = $this->getOptions();
+    $possible_values = array();
+    foreach ($options as $option_name => $option) {
+      $possible_values[$option_name] = array(
+        'value type' => 'string',
+      );
+    }
+    return $possible_values;
+  }
+}


### PR DESCRIPTION
Split visitor context cache from decision agent cache.
Enable different cache expiration settings for visitor context options.
Add in original referrer url context.
