### PR TITLE
Ch 458: Remove "please wait" indicators from execute callback executor

### DIFF
--- a/js/personalize.js
+++ b/js/personalize.js
@@ -112,10 +112,11 @@
    * chosen one.
    */
   Drupal.personalize.executors.show = {
-    'execute': function ($option_set, choice_name, osid) {
+    'execute': function ($option_set, choice_name, osid, preview) {
       var $option_source = $('script[type="text/template"]', $option_set);
       var element = $option_source.get(0);
       var json = element.innerText;
+      if (typeof preview === 'undefined') { preview = false; };
       if (json === undefined || json.length == 0) {
         json = element.text;
       }
@@ -156,17 +157,20 @@
    * option set to display.
    */
   Drupal.personalize.executors.callback = {
-  'execute': function($option_set, choice_name, osid) {
+  'execute': function($option_set, choice_name, osid, preview) {
     // Set up such that Drupal ajax handling can be utilized without a trigger.
     var custom_settings = {};
     custom_settings.url = '/personalize/option_set/' + osid + '/' + choice_name + '/ajax';
     custom_settings.event = 'onload';
     custom_settings.keypress = false;
     custom_settings.prevent = false;
-    custom_settings.progress = {
-      message: '',
-      type: 'none'
-    };
+    // Only show the throbber and wait message in preview mode.
+    if (preview !== true) {
+      custom_settings.progress = {
+        message: '',
+        type: 'none'
+      };
+    }
     var callback_action = new Drupal.ajax(null, $option_set, custom_settings);
 
     try {

--- a/js/personalize.js
+++ b/js/personalize.js
@@ -165,7 +165,7 @@
     custom_settings.prevent = false;
     custom_settings.progress = {
       message: '',
-      type: 'throbber'
+      type: 'none'
     };
     var callback_action = new Drupal.ajax(null, $option_set, custom_settings);
 

--- a/js/personalize.js
+++ b/js/personalize.js
@@ -163,6 +163,10 @@
     custom_settings.event = 'onload';
     custom_settings.keypress = false;
     custom_settings.prevent = false;
+    custom_settings.progress = {
+      message: '',
+      type: 'throbber'
+    };
     var callback_action = new Drupal.ajax(null, $option_set, custom_settings);
 
     try {

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -3,7 +3,8 @@
   Drupal.personalize = Drupal.personalize || {};
   Drupal.personalize.executors = Drupal.personalize.executors || {};
   Drupal.personalize.executors.personalizeElements = {
-    execute: function($option_set, choice_name, osid) {
+    execute: function($option_set, choice_name, osid, preview) {
+      if (typeof preview === 'undefined') { preview = false };
       var element = Drupal.settings.personalize_elements.elements[osid];
       if (element == undefined) return;
       if (Drupal.personalizeElements.hasOwnProperty(element.variation_type) && typeof Drupal.personalizeElements[element.variation_type].execute === 'function') {
@@ -13,7 +14,7 @@
         // is the control option.
         var isControl = choice_name == Drupal.settings.personalize_elements.controlOptionName;
         var selectedContent = choices[choiceIndex]['personalize_elements_content'];
-        Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid);
+        Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid, preview);
         Drupal.personalize.executorCompleted($option_set, choice_name, osid);
       }
     }
@@ -23,9 +24,12 @@
 
   Drupal.personalizeElements.replaceHtml = {
     controlContent : {},
-    execute : function($selector, selectedContent, isControl, osid) {
+    execute : function($selector, selectedContent, isControl, osid, preview) {
+      if (typeof preview === 'undefined') { preview = false };
       // We need to keep track of how we've changed the element, if only
-      // to support previewing different options.
+      // to support previewing different options.  NOTE: preview flag is only
+      // set when the call is made from preview.  The initial page load will
+      // not be in preview, even if in admin mode.
       if (!this.controlContent.hasOwnProperty(osid)) {
         this.controlContent[osid] = $selector.html();
       }
@@ -41,9 +45,12 @@
 
   Drupal.personalizeElements.addClass = {
     addedClasses : {},
-    execute : function($selector, selectedContent, isControl, osid) {
+    execute : function($selector, selectedContent, isControl, osid, preview) {
+      if (typeof preview === 'undefined') { preview = false };
       // We need to keep track of how we've changed the element, if only
-      // to support previewing different options.
+      // to support previewing different options.  NOTE: preview flag is only
+      // set when the call is made from preview.  The initial page load will
+      // not be in preview, even if in admin mode.
       if (!this.addedClasses.hasOwnProperty(osid)) {
         this.addedClasses[osid] = [];
       }
@@ -60,7 +67,8 @@
   };
 
   Drupal.personalizeElements.appendHtml = {
-    execute : function($selector, selectedContent, isControl, osid) {
+    execute : function($selector, selectedContent, isControl, osid, preview) {
+      if (typeof preview === 'undefined') { preview = false };
       var id = 'personalize-elements-append-' + osid;
       $('#' + id).remove();
       if (!isControl) {
@@ -70,7 +78,8 @@
   };
 
   Drupal.personalizeElements.prependHtml = {
-    execute : function($selector, selectedContent, isControl, osid) {
+    execute : function($selector, selectedContent, isControl, osid, preview) {
+      if (typeof preview === 'undefined') { preview = false };
       var id = 'personalize-elements-prepend-' + osid;
       $('#' + id).remove();
       if (!isControl) {


### PR DESCRIPTION
This behavior only occurs when not in preview mode.
Added preview concept to executors (even if not used in some).

See: https://github.com/acquia/acquia_lift/pull/20
