### PR TITLE
Ch 819: editHtml personalize element variation

### DIFF
--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -105,8 +105,8 @@
       // This ensures we get only the html of the $selector and not siblings.
       var $element = $element.clone().wrap('<div>').parent();
       // Remove any extraneous acquia lift / visitor actions stuff.
-      var removeClasses = /([a-zA-Z0-9-_]*-processed)|(quickedit-[a-zA-Z0-9_]*)|(acquia-lift-[a-zA-Z0-9\_\-]+)/g;
-      var removeId = /^(visitorActionsUI-)|(visitorActionsUIDialog-)|(panels-ipe-)/;
+      var removeClasses = new RegExp(Drupal.settings.visitor_actions.ignoreClasses, 'g');
+      var removeId = new RegExp(Drupal.settings.visitor_actions.ignoreIds);
       var removeTags = 'script';
 
       // Remove any invalid ids.

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -36,8 +36,9 @@
           else {
             selectedContent = selectedChoice.personalize_elements_content;
           }
-          if ($option_set.length == 0 && element.variation_type != 'runJS') {
-            // Only the runJS can do something with an empty Option Set.
+          // runJS does not require a selector and editHtml can result in an
+          // empty option set if the new html alters the DOM structure.
+          if ($option_set.length == 0 && ['runJS','editHtml'].indexOf(element.variation_type) == -1) {
             return;
           }
           Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid);
@@ -96,6 +97,7 @@
 
   Drupal.personalizeElements.editHtml = {
     controlContent: {},
+    parentElement: {},
     getOuterHtml: function($element) {
       if ($element.length > 1) {
         $element = $element.first();
@@ -136,10 +138,15 @@
       if (!this.controlContent.hasOwnProperty(osid)) {
         this.controlContent[osid] = this.getOuterHtml($selector);
       }
+      if (!this.parentElement.hasOwnProperty(osid)) {
+        // The selector gets replaced so we need to update based on the parent.
+        this.parentElement[osid] = $selector.parent();
+      }
+      var $parent = this.parentElement[osid];
       if (isControl) {
-        $selector.replaceWith(this.controlContent[osid]);
+        $parent.html(this.controlContent[osid]);
       } else {
-        $selector.replaceWith(selectedContent);
+        $parent.html(selectedContent);
       }
     },
     editInContext : function(selector, $contentInput) {

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -41,24 +41,9 @@
           if ($option_set.length == 0 && ['runJS','editHtml'].indexOf(element.variation_type) == -1) {
             return;
           }
-          Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid);
+          Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid, choice_name);
           Drupal.personalize.executorCompleted($option_set, choice_name, osid);
         }
-      }
-    },
-    /**
-     * Callback for editing or creating a personalized element in context.
-     *
-     * @param type
-     *   The variation type
-     * @param selector
-     *   The jQuery selector to the element being personalized
-     * @param $contentInput
-     *   The form input element where the value will be specified.
-     */
-    editInContext: function(type, selector, $contentInput) {
-      if (Drupal.personalizeElements[type] && typeof Drupal.personalizeElements[type].editInContext === 'function') {
-        Drupal.personalizeElements[type].editInContext(selector, $contentInput);
       }
     }
   };
@@ -81,7 +66,7 @@
     execute : function($selector, selectedContent, isControl, osid) {
       // We need to keep track of how we've changed the element, if only
       // to support previewing different options.
-      if (!this.controlContent.hasOwnProperty(osid)) {
+      if (isControl && !this.controlContent.hasOwnProperty(osid)) {
         this.controlContent[osid] = $selector.html();
       }
       if (isControl) {
@@ -132,26 +117,23 @@
       // Now return the cleaned up html.
       return $element.html();
     },
-    execute : function($selector, selectedContent, isControl, osid) {
+    execute : function($selector, selectedContent, isControl, osid, choice_name) {
       // Keep track of how the element has been changed in order to preview
       // different options.
-      if (!this.controlContent.hasOwnProperty(osid)) {
+      if (isControl && !this.controlContent.hasOwnProperty(osid)) {
         this.controlContent[osid] = this.getOuterHtml($selector);
       }
-      if (!this.parentElement.hasOwnProperty(osid)) {
+      this.parentElement[osid] = this.parentElement[osid] || {};
+      if (!this.parentElement[osid].hasOwnProperty(choice_name)) {
         // The selector gets replaced so we need to update based on the parent.
-        this.parentElement[osid] = $selector.parent();
+        this.parentElement[osid][choice_name] = $selector.parent();
       }
-      var $parent = this.parentElement[osid];
+      var $parent = this.parentElement[osid][choice_name];
       if (isControl) {
         $parent.html(this.controlContent[osid]);
       } else {
         $parent.html(selectedContent);
       }
-    },
-    editInContext : function(selector, $contentInput) {
-      var editString = this.getOuterHtml($(selector));
-      $contentInput.val(editString);
     }
   };
 
@@ -160,7 +142,7 @@
     execute : function($selector, selectedContent, isControl, osid) {
       // Keep track of how the element has been changed in order to preview
       // different options.
-      if (!this.controlContent.hasOwnProperty(osid)) {
+      if (isControl && !this.controlContent.hasOwnProperty(osid)) {
         this.controlContent[osid] = $selector.text();
       }
       if (isControl) {
@@ -168,10 +150,6 @@
       } else {
         $selector.text(selectedContent);
       }
-    },
-    editInContext : function(selector, $contentInput) {
-      var editString = $(selector).text();
-      $contentInput.val(editString);
     }
   };
 

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -103,7 +103,32 @@
       // jQuery doesn't have an outerHTML so we need to clone the child and
       // give it a parent so that we can call that parent's html function.
       // This ensures we get only the html of the $selector and not siblings.
-      return $element.clone().wrap('<div>').parent().html();
+      var $element = $element.clone().wrap('<div>').parent();
+      // Remove any extraneous acquia lift / visitor actions stuff.
+      var removeClasses = /([a-zA-Z0-9-_]*-processed)|(quickedit-[a-zA-Z0-9_]*)|(acquia-lift-[a-zA-Z0-9\_\-]+)/g;
+      var removeId = /^(visitorActionsUI-)|(visitorActionsUIDialog-)|(panels-ipe-)/;
+      var removeTags = 'script';
+
+      // Remove any invalid ids.
+      $element.find('[id]').filter(function() {
+        return removeId.test(this.id);
+      }).removeAttr('id');
+
+      // Remove any classes that are marked for ignore.
+      $element.find('[class]').each(function() {
+        var stripClasses = this.className.match(removeClasses) || [];
+        $(this).removeClass(stripClasses.join(' '));
+        if (this.className.length == 0) {
+          $(this).removeAttr('class');
+        }
+      });
+      // Remove any styling added directly from jQuery.
+      $element.find('[style]').removeAttr('style');
+      // Remove any inappropriate tags
+      $element.find(removeTags).remove();
+
+      // Now return the cleaned up html.
+      return $element.html();
     },
     execute : function($selector, selectedContent, isControl, osid) {
       // Keep track of how the element has been changed in order to preview

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -91,30 +91,8 @@
       // give it a parent so that we can call that parent's html function.
       // This ensures we get only the html of the $selector and not siblings.
       var $element = $element.clone().wrap('<div>').parent();
-      // Remove any extraneous acquia lift / visitor actions stuff.
-      var removeClasses = new RegExp(Drupal.settings.visitor_actions.ignoreClasses, 'g');
-      var removeId = new RegExp(Drupal.settings.visitor_actions.ignoreIds);
-      var removeTags = 'script';
 
-      // Remove any invalid ids.
-      $element.find('[id]').filter(function() {
-        return removeId.test(this.id);
-      }).removeAttr('id');
-
-      // Remove any classes that are marked for ignore.
-      $element.find('[class]').each(function() {
-        var stripClasses = this.className.match(removeClasses) || [];
-        $(this).removeClass(stripClasses.join(' '));
-        if (this.className.length == 0) {
-          $(this).removeAttr('class');
-        }
-      });
-      // Remove any styling added directly from jQuery.
-      $element.find('[style]').removeAttr('style');
-      // Remove any inappropriate tags
-      $element.find(removeTags).remove();
-
-      // Now return the cleaned up html.
+      // Now return the child html of our wrapper parent tag.
       return $element.html();
     },
     execute : function($selector, selectedContent, isControl, osid) {

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -44,6 +44,21 @@
           Drupal.personalize.executorCompleted($option_set, choice_name, osid);
         }
       }
+    },
+    /**
+     * Callback for editing or creating a personalized element in context.
+     *
+     * @param type
+     *   The variation type
+     * @param selector
+     *   The jQuery selector to the element being personalized
+     * @param $contentInput
+     *   The form input element where the value will be specified.
+     */
+    editInContext: function(type, selector, $contentInput) {
+      if (typeof Drupal.personalizeElements[type] && Drupal.personalizeElements[type].editInContext === 'function') {
+        Drupal.personalizeElements[type].editInContext(selector, $contextInput);
+      }
     }
   };
 

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -155,6 +155,26 @@
     }
   };
 
+  Drupal.personalizeElements.editText = {
+    controlContent: {},
+    execute : function($selector, selectedContent, isControl, osid) {
+      // Keep track of how the element has been changed in order to preview
+      // different options.
+      if (!this.controlContent.hasOwnProperty(osid)) {
+        this.controlContent[osid] = $selector.text();
+      }
+      if (isControl) {
+        $selector.text(this.controlContent[osid]);
+      } else {
+        $selector.text(selectedContent);
+      }
+    },
+    editInContext : function(selector, $contentInput) {
+      var editString = $(selector).text();
+      $contentInput.val(editString);
+    }
+  };
+
   Drupal.personalizeElements.addClass = {
     addedClasses : {},
     execute : function($selector, selectedContent, isControl, osid) {

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -41,7 +41,7 @@
           if ($option_set.length == 0 && ['runJS','editHtml'].indexOf(element.variation_type) == -1) {
             return;
           }
-          Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid, choice_name);
+          Drupal.personalizeElements[element.variation_type].execute($option_set, selectedContent, isControl, osid);
           Drupal.personalize.executorCompleted($option_set, choice_name, osid);
         }
       }
@@ -117,18 +117,17 @@
       // Now return the cleaned up html.
       return $element.html();
     },
-    execute : function($selector, selectedContent, isControl, osid, choice_name) {
+    execute : function($selector, selectedContent, isControl, osid) {
       // Keep track of how the element has been changed in order to preview
       // different options.
       if (isControl && !this.controlContent.hasOwnProperty(osid)) {
         this.controlContent[osid] = this.getOuterHtml($selector);
       }
-      this.parentElement[osid] = this.parentElement[osid] || {};
-      if (!this.parentElement[osid].hasOwnProperty(choice_name)) {
+      if (!this.parentElement.hasOwnProperty(osid)) {
         // The selector gets replaced so we need to update based on the parent.
-        this.parentElement[osid][choice_name] = $selector.parent();
+        this.parentElement[osid] = $selector.parent();
       }
-      var $parent = this.parentElement[osid][choice_name];
+      var $parent = this.parentElement[osid];
       if (isControl) {
         $parent.html(this.controlContent[osid]);
       } else {

--- a/modules/personalize_elements/js/personalize_elements.js
+++ b/modules/personalize_elements/js/personalize_elements.js
@@ -56,8 +56,8 @@
      *   The form input element where the value will be specified.
      */
     editInContext: function(type, selector, $contentInput) {
-      if (typeof Drupal.personalizeElements[type] && Drupal.personalizeElements[type].editInContext === 'function') {
-        Drupal.personalizeElements[type].editInContext(selector, $contextInput);
+      if (Drupal.personalizeElements[type] && typeof Drupal.personalizeElements[type].editInContext === 'function') {
+        Drupal.personalizeElements[type].editInContext(selector, $contentInput);
       }
     }
   };
@@ -91,6 +91,35 @@
         Drupal.attachBehaviors($selector);
       }
 
+    }
+  };
+
+  Drupal.personalizeElements.editHtml = {
+    controlContent: {},
+    getOuterHtml: function($element) {
+      if ($element.length > 1) {
+        $element = $element.first();
+      }
+      // jQuery doesn't have an outerHTML so we need to clone the child and
+      // give it a parent so that we can call that parent's html function.
+      // This ensures we get only the html of the $selector and not siblings.
+      return $element.clone().wrap('<div>').parent().html();
+    },
+    execute : function($selector, selectedContent, isControl, osid) {
+      // Keep track of how the element has been changed in order to preview
+      // different options.
+      if (!this.controlContent.hasOwnProperty(osid)) {
+        this.controlContent[osid] = this.getOuterHtml($selector);
+      }
+      if (isControl) {
+        $selector.replaceWith(this.controlContent[osid]);
+      } else {
+        $selector.replaceWith(selectedContent);
+      }
+    },
+    editInContext : function(selector, $contentInput) {
+      var editString = this.getOuterHtml($(selector));
+      $contentInput.val(editString);
     }
   };
 

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -115,11 +115,15 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
 
   $variation_type_options = array();
   $selector_states = array();
-  $variation_types = module_invoke_all('personalize_elements_variation_types');
+  $variation_types = module_invoke_all('personalize_elements_variation_types', TRUE, FALSE);
   foreach ($variation_types as $type => $info) {
-    $variation_type_options[$type] = $info['label'];
-    if ($info['needs_selector']) {
-      $selector_states[] = array('select[name="variation_type"]' => array("value" => $type));
+    // Show only active types unless it is the current type of an existing
+    // option set.
+    if ($info['active'] || (!empty($option_set->data['personalize_elements_type']) && $option_set->data['personalize_elements_type'] === $type)) {
+      $variation_type_options[$type] = $info['label'];
+      if ($info['needs_selector']) {
+        $selector_states[] = array('select[name="variation_type"]' => array("value" => $type));
+      }
     }
   }
 

--- a/modules/personalize_elements/personalize_elements.api.php
+++ b/modules/personalize_elements/personalize_elements.api.php
@@ -6,6 +6,8 @@
  * @param $filter_by_perms
  *   Indicates if the array of types should be filtered based on the current
  *   user's permissions.
+ * @param bool $filter_active
+ *   True to restrict the returned variations to those having an active status.
  * @return array
  *   An array of variation types.  The key should be the same as the key for
  *   JavaScript functionality to execute in order to personalize.  Each type
@@ -17,16 +19,19 @@
  *     content variation creation process.  FALSE if this variation should
  *     not be included.  In order to be included the type must also have
  *     needs_selector => TRUE.
+ *   - active: True to indicate the variation type can be used for new
+ *     variations and false for variation types that have been retired.
  *     - label: The label for this item to be displayed within contextual
  *       creation menu
  *     - formitem: A form field render array for the
  *       personalize_elements_content to be collected for this variation.
  */
-function hook_personalize_elements_variation_types($filter_by_perms = TRUE) {
+function hook_personalize_elements_variation_types($filter_by_perms = TRUE, $filter_active = TRUE) {
   return array(
     'myVariationType' => array(
       'label' => t('Change something'),
       'needs_selector' => TRUE,
+      'active' => TRUE,
       'contextual' => array(
         'label' => t('Change something'),
         'formitem' => array(

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -259,6 +259,23 @@ function personalize_elements_personalize_elements_variation_types($filter_by_pe
       ),
     ),
   );
+  $types['editText'] = array(
+    'label' => t('Edit the text'),
+    'needs_selector' => TRUE,
+    'active' => TRUE,
+    'contextual' => array(
+      'label' => t('Edit text'),
+      'formitem' => array(
+        '#type' => 'textarea',
+        '#title' => t('Text'),
+        '#rows' => 6,
+        '#required' => TRUE,
+      ),
+    ),
+    // Limits this option to selectors that only have children with the nodeType
+    // of 3 (text).
+    'limitByChildrenType' => '3',
+  );
   $types['addClass'] = array(
     'label' => t('Add a class'),
     'needs_selector' => TRUE,
@@ -367,7 +384,10 @@ function personalize_elements_contextual_menu_variations() {
   $options = array();
   foreach ($variation_types as $type => $info) {
     if ($info['contextual'] && $info['contextual'] !== FALSE) {
-      $options[$type] = $info['contextual']['label'];
+      $options[$type] = array(
+        'name' => $info['contextual']['label'],
+        'limitByChildrenType' => isset($info['limitByChildrenType']) ? $info['limitByChildrenType'] : '',
+      );
     }
   }
   return $options;

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -390,11 +390,6 @@ function personalize_elements_get_option_for_variation($option_id, $option_label
     'option_id' => $option_id,
     'option_label' => $option_label,
   );
-  // The execution of personalize elements assumes that if the content attribute
-  // is missing then it is the control option.
-  if ($option_id !== PERSONALIZE_CONTROL_OPTION_ID) {
-    $option['personalize_elements_content'] = '';
-  }
   return $option;
 }
 

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -256,7 +256,6 @@ function personalize_elements_personalize_elements_variation_types($filter_by_pe
         '#title' => t('HTML'),
         '#rows' => 6,
         '#required' => TRUE,
-        '#description' => t('Changing the enclosing element can break variation previews.'),
       ),
     ),
   );

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -376,6 +376,29 @@ function personalize_elements_get_option_set_for_variation($title, $agent_name, 
 }
 
 /**
+ * Generates an empty option to be included in a page variation.
+ *
+ * @param $option_id
+ *   The id for the option
+ * @param $option_label
+ *   The label for the option
+ * @return array
+ *   An option array
+ */
+function personalize_elements_get_option_for_variation($option_id, $option_label) {
+  $option = array(
+    'option_id' => $option_id,
+    'option_label' => $option_label,
+  );
+  // The execution of personalize elements assumes that if the content attribute
+  // is missing then it is the control option.
+  if ($option_id !== PERSONALIZE_CONTROL_OPTION_ID) {
+    $option['personalize_elements_content'] = '';
+  }
+  return $option;
+}
+
+/**
  * Gets the variation types available for use within a contextual menu
  * specific to an element.
  */

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -226,11 +226,13 @@ function personalize_elements_personalize_delete_link($option_set) {
 /**
  * Implements hook_personalize_elements_variation_types().
  */
-function personalize_elements_personalize_elements_variation_types($filter_by_perms = TRUE) {
-  $types = array(
-    'replaceHtml' => array(
+function personalize_elements_personalize_elements_variation_types($filter_by_perms = TRUE, $filter_active = TRUE) {
+  $types = array();
+  if (!$filter_active) {
+    $types['replaceHtml'] = array(
       'label' => t('Replace the html'),
       'needs_selector' => TRUE,
+      'active' => FALSE,
       'contextual' => array(
         'label' => t('Edit HTML'),
         'formitem' => array(
@@ -240,43 +242,46 @@ function personalize_elements_personalize_elements_variation_types($filter_by_pe
           '#required' => TRUE,
         ),
       ),
-    ),
-    'addClass' => array(
-      'label' => t('Add a class'),
-      'needs_selector' => TRUE,
-      'contextual' => array(
-        'label' => t('Add CSS class'),
-        'formitem' => array(
-          '#type' => 'textfield',
-          '#title' => t('New class'),
-          '#required' => TRUE,
-        ),
+    );
+  }
+  $types['addClass'] = array(
+    'label' => t('Add a class'),
+    'needs_selector' => TRUE,
+    'active' => TRUE,
+    'contextual' => array(
+      'label' => t('Add CSS class'),
+      'formitem' => array(
+        '#type' => 'textfield',
+        '#title' => t('New class'),
+        '#required' => TRUE,
       ),
     ),
-    'appendHtml' => array(
+  );
+  $types['appendHtml'] = array(
+    'label' => t('Append HTML'),
+    'needs_selector' => TRUE,
+    'active' => TRUE,
+    'contextual' => array(
       'label' => t('Append HTML'),
-      'needs_selector' => TRUE,
-      'contextual' => array(
-        'label' => t('Append HTML'),
-        'formitem' => array(
-          '#type' => 'textarea',
-          '#title' => t('HTML'),
-          '#rows' => 4,
-          '#required' => TRUE,
-        ),
+      'formitem' => array(
+        '#type' => 'textarea',
+        '#title' => t('HTML'),
+        '#rows' => 4,
+        '#required' => TRUE,
       ),
     ),
-    'prependHtml' => array(
+  );
+  $types['prependHtml'] = array(
+    'label' => t('Prepend HTML'),
+    'needs_selector' => TRUE,
+    'active' => TRUE,
+    'contextual' => array(
       'label' => t('Prepend HTML'),
-      'needs_selector' => TRUE,
-      'contextual' => array(
-        'label' => t('Prepend HTML'),
-        'formitem' => array(
-          '#type' => 'textarea',
-          '#title' => t('HTML'),
-          '#rows' => 4,
-          '#required' => TRUE,
-        ),
+      'formitem' => array(
+        '#type' => 'textarea',
+        '#title' => t('HTML'),
+        '#rows' => 4,
+        '#required' => TRUE,
       ),
     ),
   );
@@ -285,6 +290,7 @@ function personalize_elements_personalize_elements_variation_types($filter_by_pe
       'label' => t('Run JavaScript code'),
       'needs_selector' => FALSE,
       'contextual' => FALSE,
+      'active' => TRUE,
     );
   }
   return $types;

--- a/modules/personalize_elements/personalize_elements.module
+++ b/modules/personalize_elements/personalize_elements.module
@@ -229,6 +229,7 @@ function personalize_elements_personalize_delete_link($option_set) {
 function personalize_elements_personalize_elements_variation_types($filter_by_perms = TRUE, $filter_active = TRUE) {
   $types = array();
   if (!$filter_active) {
+    // Retired in favor of editHtml below.
     $types['replaceHtml'] = array(
       'label' => t('Replace the html'),
       'needs_selector' => TRUE,
@@ -244,6 +245,21 @@ function personalize_elements_personalize_elements_variation_types($filter_by_pe
       ),
     );
   }
+  $types['editHtml'] = array(
+    'label' => t('Edit the html'),
+    'needs_selector' => TRUE,
+    'active' => TRUE,
+    'contextual' => array(
+      'label' => t('Edit HTML'),
+      'formitem' => array(
+        '#type' => 'textarea',
+        '#title' => t('HTML'),
+        '#rows' => 6,
+        '#required' => TRUE,
+        '#description' => t('Changing the enclosing element can break variation previews.'),
+      ),
+    ),
+  );
   $types['addClass'] = array(
     'label' => t('Add a class'),
     'needs_selector' => TRUE,

--- a/modules/personalize_elements/tests/personalize_elements.test
+++ b/modules/personalize_elements/tests/personalize_elements.test
@@ -76,7 +76,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $this->drupalPost('admin/structure/personalize/variations/personalize-elements/add', $edit, $this->getButton('save'));
     $this->assertText('You must choose an operation');
 
-    $edit['variation_type'] = 'replaceHtml';
+    $edit['variation_type'] = 'appendHtml';
     $this->assertFieldByName('options[0][option_label]', PERSONALIZE_CONTROL_OPTION_LABEL);
     $this->drupalPost('admin/structure/personalize/variations/personalize-elements/add', $edit, $this->getButton('save'));
     $this->assertText($options_count_error);
@@ -214,7 +214,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
       'agent_select' => 'test-agent',
       'title' => $this->randomName(),
       'selector' => '#some-id',
-      'variation_type' => 'replaceHtml',
+      'variation_type' => 'appendHtml',
       'options[1][option_label]' => 'first-option',
       'options[1][personalize_elements_content]' => '<script type="text/javascript">alert("xss");</script>',
     );
@@ -276,7 +276,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
       'agent_basic_info[title]' => $agent_name,
       'agent_basic_info[options][test_agent][use_client_side_goal_processing]' => FALSE,
       'title' => $this->randomName(),
-      'variation_type' => 'replaceHtml',
+      'variation_type' => 'appendHtml',
       'selector' => '#some-id',
       'add_control_option' => TRUE,
       'options[1][option_label]' => 'first-option',
@@ -315,6 +315,57 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $option_set = personalize_option_set_load(1, TRUE);
     $this->assertEqual('ohai', $option_set->options[1]['personalize_elements_content']);
     $this->assertEqual('<a href="/">kthxbai</a>', $option_set->options[2]['personalize_elements_content']);
+  }
+
+  /**
+   * Tests that inactive variation types are only available for backwards
+   * compatibility.
+   */
+  function testPersonalizeElementsStatus() {
+    $admin_user = $this->drupalCreateUser(array('access administration pages', 'administer site configuration', 'access content', 'manage personalized content'));
+    $this->drupalLogin($admin_user);
+
+    // First verify that the retired variation type is not available in a
+    // new form.
+    $this->drupalGet('admin/structure/personailze/variations/personalize-elements/add');
+    $this->assertNoRaw('<option value="replaceHtml">Replace the html</option>');
+
+    // Create an option set of an inactive variation type.
+    $option_set = array(
+      'label' => $this->randomName(),
+      'plugin' => 'elements',
+      'agent' => 'test-agent',
+      'executor' => 'personalizeElements',
+      'options' => array(
+        array(
+          'option_id' => PERSONALIZE_CONTROL_OPTION_ID,
+          'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL,
+          'personalize_elements_content' => '',
+        ),
+        array(
+          'option_id' => personalize_generate_option_label(1),
+          'option_label' => $this->randomName(),
+          'personalize_elements_content' => $this->randomString(),
+        ),
+      ),
+      'data' => array(
+        'personalize_elements_selector' => '.some-class-name',
+        'personalize_elements_type' => 'replaceHtml',
+        'pages' => '',
+      ),
+    );
+    $option_set = personalize_option_set_save((object) $option_set);
+
+    // Edit the option set and verify that the inactive type is available in the
+    // variation type select list.
+    $this->drupalGet('admin/structure/personalize/variations/personalize-elements/manage/' . $option_set->osid . '/edit');
+    $this->assertOptionSelected('edit-variation-type', 'replaceHtml');
+
+    // Create a new element with an active variation type and verify that the
+    // edit page does not include the inactive variation type.
+    $active_option_set = $this->createPersonalizedElement(array('selector' => '.some-other-class-name', 'variation_type' => 'addClass'));
+    $this->drupalGet('admin/structure/personalize/variations/personalize-elements/manage/' . $active_option_set->osid . '/edit');
+    $this->assertNoRaw('<option value="replaceHtml">Replace the html</option>');
   }
 
   /**
@@ -388,7 +439,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
       'agent_select' => 'test-agent',
       'title' => $this->randomName(),
       'selector' => '#some-id',
-      'variation_type' => 'replaceHtml',
+      'variation_type' => 'appendHtml',
       'add_control_option' => TRUE,
       'pages' => '',
       'options[1][option_label]' => personalize_generate_option_label(1),

--- a/modules/personalize_elements/tests/personalize_elements.test
+++ b/modules/personalize_elements/tests/personalize_elements.test
@@ -411,7 +411,7 @@ class PersonalizeElementsTest extends DrupalWebTestCase {
     $this->assertEqual($expected, $personalize_elements_settings['elements']);
 
     // Check for the contextual settings for a few of the variation types.
-    $this->assertEqual(t("Add CSS class"), $personalize_elements_settings['contextualVariationTypes']['addClass']);
+    $this->assertEqual(t("Add CSS class"), $personalize_elements_settings['contextualVariationTypes']['addClass']['name']);
     $this->assertFalse(isset($personalize_elements['contextualVariationTypes']['runJS']));
   }
 


### PR DESCRIPTION
Allow a variation type to be retired by still available for backwards compatibility.
Add an editHtml personalize variation type.
Created a callback mechanism for edit in context:
- I placed this in the main personalize_elements.js file and I'm conflicted about that.  The structure was there to support multiple callback types per variation type but it's technically the admin layer and not the main layer.  However, I also don't want to add even more javascript files to the page when we only need a little callback.  I welcome new thoughts on this... it would be easy enough to move if there was something else that worked better and felt less cludgy.
