### PR TITLE
Ch 905: Indicate if campaigns should be included in navigation

### DIFF
--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -39,6 +39,20 @@ function personalize_fields_personalize_option_set_type() {
 }
 
 /**
+ * Implements hook_personalize_option_set_show_in_navigation().
+ */
+function personalize_fields_personalize_option_set_show_in_navigation($option_set, $path) {
+  // An node's personalize fields option set should be shown in the navigation only for that node's page.
+  if (empty($option_set->data['personalize_fields_entity_type']) || $option_set->data['personalize_fields_entity_type'] !== 'node' || empty($option_set->data['personalize_fields_entity_id'])) {
+    return TRUE;
+  }
+
+  // Check if the $path to check matches the node path.
+  $node_path = drupal_get_path_alias('node/'. $option_set->data['personalize_fields_entity_id']);
+  return drupal_get_path_alias($path) == $node_path;
+}
+
+/**
  * Implements hook_ctools_plugin_api().
  */
 function personalize_fields_ctools_plugin_api($owner, $api) {

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -47,9 +47,15 @@ function personalize_fields_personalize_option_set_show_in_navigation($option_se
     return TRUE;
   }
 
-  // Check if the $path to check matches the node path.
-  $node_path = drupal_get_path_alias('node/'. $option_set->data['personalize_fields_entity_id']);
-  return drupal_get_path_alias($path) == $node_path;
+  // Check if the $path to check matches the entity path.
+  // @todo - this will not match the edit path, however you really don't need to
+  // manage the campaign in context there, nor can you preview.
+  $entity_type = $option_set->data['personalize_fields_entity_type'];
+  $entity_id = $option_set->data['personalize_fields_entity_id'];
+  $entities = entity_load($entity_type, array($entity_id));
+  $entity_url = entity_uri($entity_type, $entities[$entity_id]);
+  $check_path = drupal_get_path_alias($path);
+  return $check_path == drupal_get_path_alias($entity_url['path']);
 }
 
 /**

--- a/modules/personalize_fields/tests/personalize_fields.test
+++ b/modules/personalize_fields/tests/personalize_fields.test
@@ -132,6 +132,7 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $this->drupalGet('node/add/article');
     $this->drupalPost(NULL, NULL, t('Add another item'));
     $this->drupalPost(NULL, $edit, t('Save'));
+
     $this->assertNoText('The campaign type specified for this field does not exist. Please go to the field settings and choose an existing campaign type.');
     // Assert that we can load the new option set from the db.
     $option_set = personalize_option_set_load(1);
@@ -170,6 +171,11 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $cached = cache_get($cid, PERSONALIZE_FIELDS_CACHE_BIN);
     $this->assertEqual(1, $cached->data);
 
+    // Confirm that the campaign is set to be included in the navigation on the article node page.
+    $this->drupalGet('node/1');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['campaigns'][$agent->machine_name]['includeNavigation'], TRUE);
+
     // Create another node with a personalized headline
     // Set up two headline options
     $this->drupalGet('node/add/article');
@@ -179,6 +185,7 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $edit['article_headline[und][0][value]'] = 'first option';
     $edit['article_headline[und][1][value]'] = 'second option';
     $this->drupalPost(NULL, $edit, t('Save'));
+
     $option_set = personalize_option_set_load(2);
     $second_agent = 'article-personalizable-headline-2';
     $this->assertEqual($second_agent, $option_set->agent);
@@ -186,6 +193,13 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     // Confirm that the agent's human-readable name has been generated correctly.
     $agent = personalize_agent_load($second_agent);
     $this->assertEqual('Article Personalizable Headline 2', $agent->label);
+
+    // Confirm that the new campaign is available for the navigation on its node page but not the first campaign.
+    $this->drupalGet('node/2');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['campaigns'][$first_agent]['includeNavigation'], FALSE);
+    $this->assertEqual($settings['personalize']['campaigns'][$second_agent]['includeNavigation'], TRUE);
+
     // Add another headline option to the first node and confirm that the agent is paused.
     personalize_agent_set_status($first_agent, PERSONALIZE_STATUS_RUNNING);
     $this->drupalPost('node/1/edit', NULL, t('Add another item'));
@@ -201,8 +215,14 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $this->assertEqual($options, $option_set->options);
     personalize_option_set_load_by_agent($first_agent, TRUE);
 
-    // Restart the agent and confirm that removing an option pauses the agent.
+    // Confirm that the correct campaigns are set to be included in navigation.
+    $this->drupalGet('node/1');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['campaigns'][$first_agent]['includeNavigation'], TRUE);
+    $this->assertEqual($settings['personalize']['campaigns'][$second_agent]['includeNavigation'], FALSE);
+
     $this->drupalGet('node/1/edit');
+    // Restart the agent and confirm that removing an option pauses the agent.
     personalize_agent_set_status($first_agent, PERSONALIZE_STATUS_RUNNING);
     $edit['article_headline[und][2][value]'] = '';
     $this->drupalPost(NULL, $edit, t('Save'));
@@ -236,6 +256,7 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
 
     // Restart the agent and make sure that other changes do not cause pausing.
     $this->drupalGet('node/1/edit');
+
     personalize_agent_set_status($first_agent, PERSONALIZE_STATUS_RUNNING);
     $edit['title'] = $this->randomName(8);
     $edit['article_headline[und][0][value]'] .= ': edited';
@@ -266,6 +287,12 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     );
     $this->assertEqual($field_info, $option_set->field_info);
 
+    // Now both campaigns should show on the second node because the first campaign is empty.
+    $this->drupalGet('node/2');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['campaigns'][$first_agent]['includeNavigation'], TRUE);
+    $this->assertEqual($settings['personalize']['campaigns'][$second_agent]['includeNavigation'], TRUE);
+
     // Confirm that there's also a corresponding record in the cache table.
     $cid = _personalize_fields_get_cid_for_field('node', 2, 'article_headline');
     $cached = cache_get($cid, PERSONALIZE_FIELDS_CACHE_BIN);
@@ -277,6 +304,13 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $edit['title'] = $this->randomName(8);
     $edit['article_headline[und][0][value]'] = 'only option';
     $this->drupalPost('node/add/article', $edit, t('Save'));
+
+    // Confirm the correct navigation settings.
+    $this->drupalGet('node/3');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['campaigns'][$first_agent]['includeNavigation'], TRUE);
+    $this->assertEqual($settings['personalize']['campaigns'][$second_agent]['includeNavigation'], FALSE);
+
     // Confirm that there is no third option set.
     $option_set = personalize_option_set_load(3);
     $this->assertFalse($option_set);
@@ -298,6 +332,7 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     $edit['article_headline[und][0][value]'] = 'first option';
     $edit['article_headline[und][1][value]'] = 'second option';
     $this->drupalPost(NULL, $edit, t('Save'));
+
     // Confirm that an option set has been created for this node.
     $option_set = personalize_option_set_load(3);
     $this->assertEqual('fields', $option_set->plugin);
@@ -308,6 +343,14 @@ class PersonalizeFieldsTest extends DrupalWebTestCase {
     );
     $this->assertEqual($field_info, $option_set->field_info);
     $third_agent = 'article-personalizable-headline-3';
+
+    // Check which campaigns are included in navigation.
+    $this->drupalGet('node/4');
+    $settings = $this->drupalGetSettings();
+    $this->assertEqual($settings['personalize']['campaigns'][$first_agent]['includeNavigation'], TRUE);
+    $this->assertEqual($settings['personalize']['campaigns'][$second_agent]['includeNavigation'], FALSE);
+    $this->assertEqual($settings['personalize']['campaigns'][$third_agent]['includeNavigation'], TRUE);
+
     personalize_agent_set_status($third_agent, PERSONALIZE_STATUS_RUNNING);
     // Now remove all but one option.
     $edit['article_headline[und][1][value]'] = '';

--- a/personalize.api.php
+++ b/personalize.api.php
@@ -276,6 +276,24 @@ function hook_personalize_campaign_report($agent_data, $option_set) {
 }
 
 /**
+ * Returns whether or not a campaign should be included in navigation based
+ * on the option set data and a selected page.
+ *
+ * If a module does not implement this hook, then it will be assumed that the
+ * option set should be shown in the navigation for all pages.
+ *
+ * @param stdClass $option_set
+ *   The option set.
+ * @param string $path
+ *   The path where the option set could be shown.
+ * @return boolen
+ *   True if the option set should be shown or false if it should not.
+ */
+function hook_personalize_option_set_show_in_navigation($option_set, $path) {
+
+}
+
+/**
  * Allows alteration the array of available executors.
  *
  * @param array $executors

--- a/personalize.module
+++ b/personalize.module
@@ -471,6 +471,7 @@ function personalize_agent_get_settings() {
         'status' => $next_status,
         'text' => $status_text,
       ),
+      'includeNavigation' => personalize_agent_include_in_navigation($agent->machine_name),
       'links' => array(
         'view' => '/admin/structure/personalize/manage/' . $agent->machine_name,
         'edit' => '/admin/structure/personalize/manage/' . $agent->machine_name . '/edit',
@@ -486,6 +487,42 @@ function personalize_agent_get_settings() {
     unset($goals);
   }
   return $campaigns;
+}
+
+/**
+ * Determines if a campaign should be included in navigation campaign lists.
+ *
+ * @param $agent_name
+ *   The machine name of the campaign.
+ * @param $compare_path
+ *   (Optional) The page where the campaign may be shown.  Defaults to the
+ *   current page.
+ * @return bool
+ *   True to include in navigation, false to exclude.
+ */
+function personalize_agent_include_in_navigation($agent_name, $compare_path = NULL) {
+  $path = empty($compare_path) ? drupal_strtolower(drupal_get_path_alias($_GET['q'])) : $compare_path;
+
+  // A campaign should be shown if any of its option sets should be shown.
+  $option_sets = personalize_option_set_load_by_agent($agent_name);
+
+  // Show a campaign with no option sets because it needs to be set up.
+  if (empty($option_sets)) {
+    return TRUE;
+  }
+  foreach ($option_sets as $option_set) {
+    $option_set_plugin = personalize_get_option_set_type($option_set->plugin);
+    // If a module doesn't implement this hook, then it is assumed that the
+    // option set should be shown (and therefore the campaign).
+    if (!module_implements('personalize_option_set_show_in_navigation')) {
+      return TRUE;
+    }
+    $show = module_invoke($option_set_plugin['module'], 'personalize_option_set_show_in_navigation', $option_set, $path);
+    if ($show) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }
 
 /**

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1851,6 +1851,7 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
           'status' => PERSONALIZE_STATUS_RUNNING,
           'text' => t('Start'),
         ),
+        'includeNavigation' => TRUE,
         'links' => array(
           'edit' => '/admin/structure/personalize/manage/' . $first_agent_machine_name . '/edit',
           'report' => '/admin/structure/personalize/manage/' . $first_agent_machine_name . '/report',
@@ -1869,6 +1870,7 @@ class PersonalizeAdministrationTest extends PersonalizeBaseTest {
           'status' => PERSONALIZE_STATUS_RUNNING,
           'text' => t('Start'),
         ),
+        'includeNavigation' => TRUE,
         'links' => array(
           'edit' => '/admin/structure/personalize/manage/' . $second_agent_machine_name . '/edit',
           'report' => '',


### PR DESCRIPTION
Personalize fields limits which campaigns are shown.
