### PR TITLE
Ch 1147: Delete goals from unibar.

### DIFF
--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1255,6 +1255,10 @@ function personalize_agent_goals_form($form, &$form_state, $agent_data) {
         'id' => 'edit-goals-' . $delta . '-remove',
         'class' => array('personalize-delete-goal', 'form-submit',),
         'title' => t('Delete the goal.'),
+        // Adding the name and value attributes allows for targeting within
+        // simpletest.
+        'name' => 'edit-goals-' . $delta . '-remove',
+        'value' => t('Remove'),
       ),
       '#submit' => array('personalize_agent_remove_goal_submit'),
       '#ajax' => array(

--- a/personalize.module
+++ b/personalize.module
@@ -2818,7 +2818,7 @@ function personalize_goal_delete($goal_id, $rebuild_subscribers = TRUE) {
     }
   }
   // Clear the agent's goals cache.
-  personalize_goal_load_by_conditions(array('agent' => $fields['agent']), TRUE);
+  $goals = personalize_goal_load_by_conditions(array('agent' => $fields['agent']), TRUE);
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -453,7 +453,11 @@ function personalize_agent_get_settings() {
     }
     $supports_goals = $plugin instanceof PersonalizeAgentGoalInterface;
     if ($supports_goals) {
-      $goals = personalize_agent_get_goal_settings($agent->machine_name);
+      foreach (personalize_goal_load_by_conditions(array('agent' => $agent->machine_name)) as $goal) {
+        if (isset($actions[$goal->action])) {
+          $goals[$goal->action] = check_plain($actions[$goal->action]['label']);
+        }
+      }
     }
     $current_status = personalize_agent_get_status($agent->machine_name);
     list($next_status, $status_text) = _personalize_status_toggle_next($current_status);
@@ -488,22 +492,6 @@ function personalize_agent_get_settings() {
     unset($goals);
   }
   return $campaigns;
-}
-
-/**
- * Loads the goals for a campaign and formats for use as JavaScript settings.
- * @param $agent_name
- *   The machine name for the campaign to load
- */
-function personalize_agent_get_goal_settings($agent_name) {
-  $actions = visitor_actions_get_actions();
-  $goals = array();
-  foreach (personalize_goal_load_by_conditions(array('agent' => $agent_name)) as $goal) {
-    if (isset($actions[$goal->action])) {
-      $goals[$goal->action] = check_plain($actions[$goal->action]['label']);
-    }
-  }
-  return $goals;
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -2708,9 +2708,16 @@ function personalize_goal_load_multiple($ids = FALSE, $conditions = array(), $re
 
 /**
  * Loads all goals satisfying the specified conditions.
+ *
+ * @param array $conditions
+ *   An array of conditions to constrain the query to.
+ * @param bool $reset
+ *   Whether to reset the cache and load fresh from the DB.
+ * @return array
+ *   An array of Goal objects.
  */
-function personalize_goal_load_by_conditions($conditions = array()) {
-  return personalize_goal_load_multiple(array(), $conditions);
+function personalize_goal_load_by_conditions($conditions = array(), $reset = FALSE) {
+  return personalize_goal_load_multiple(array(), $conditions, $reset);
 }
 
 /**
@@ -2768,22 +2775,22 @@ function personalize_visitor_actions_delete_action($action) {
  *   TRUE if the action subscribers cache needs to be rebuilt
  */
 function personalize_goal_delete($goal_id, $rebuild_subscribers = TRUE) {
-  $action_name = db_select('personalize_campaign_goals', 'g')
-    ->fields('g', array('action'))
+  $fields = db_select('personalize_campaign_goals', 'g')
+    ->fields('g', array('action', 'agent'))
     ->condition('id', $goal_id)
     ->execute()
-    ->fetchField();
+    ->fetchAssoc();
 
   // Delete the goal.
   db_delete('personalize_campaign_goals')
     ->condition('id', $goal_id)
     ->execute();
 
-  $action = visitor_actions_custom_load($action_name);
+  $action = visitor_actions_custom_load($fields['action']);
   if ($action) {
     // If the underlying action was a limited usage action, then delete it too.
     if (!empty($action['limited_use'])) {
-      visitor_actions_delete_action($action_name);
+      visitor_actions_delete_action($fields['action']);
     }
   }
   if ($rebuild_subscribers) {
@@ -2791,13 +2798,15 @@ function personalize_goal_delete($goal_id, $rebuild_subscribers = TRUE) {
     // a goal that uses this action.
     $result = db_select('personalize_campaign_goals', 'g')
       ->fields('g', array('action'))
-      ->condition('action', $action_name)
+      ->condition('action', $fields['action'])
       ->execute()
       ->fetchField();
     if (!$result) {
-      visitor_actions_clear_subscribers($action_name);
+      visitor_actions_clear_subscribers($fields['action']);
     }
   }
+  // Clear the agent's goals cache.
+  personalize_goal_load_by_conditions(array('agent' => $fields['agent']), TRUE);
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -2819,6 +2819,9 @@ function personalize_goal_delete($goal_id, $rebuild_subscribers = TRUE) {
   }
   // Clear the agent's goals cache.
   $goals = personalize_goal_load_by_conditions(array('agent' => $fields['agent']), TRUE);
+  if (empty($goals)) {
+    personalize_pause_if_running($fields['agent']);
+  }
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -453,11 +453,7 @@ function personalize_agent_get_settings() {
     }
     $supports_goals = $plugin instanceof PersonalizeAgentGoalInterface;
     if ($supports_goals) {
-      foreach (personalize_goal_load_by_conditions(array('agent' => $agent->machine_name)) as $goal) {
-        if (isset($actions[$goal->action])) {
-          $goals[$goal->action] = check_plain($actions[$goal->action]['label']);
-        }
-      }
+      $goals = personalize_agent_get_goal_settings($agent->machine_name);
     }
     $current_status = personalize_agent_get_status($agent->machine_name);
     list($next_status, $status_text) = _personalize_status_toggle_next($current_status);
@@ -492,6 +488,22 @@ function personalize_agent_get_settings() {
     unset($goals);
   }
   return $campaigns;
+}
+
+/**
+ * Loads the goals for a campaign and formats for use as JavaScript settings.
+ * @param $agent_name
+ *   The machine name for the campaign to load
+ */
+function personalize_agent_get_goal_settings($agent_name) {
+  $actions = visitor_actions_get_actions();
+  $goals = array();
+  foreach (personalize_goal_load_by_conditions(array('agent' => $agent_name)) as $goal) {
+    if (isset($actions[$goal->action])) {
+      $goals[$goal->action] = check_plain($actions[$goal->action]['label']);
+    }
+  }
+  return $goals;
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -2759,7 +2759,8 @@ function personalize_visitor_actions_delete_action($action) {
 }
 
 /**
- * Deletes a goal from the db.
+ * Deletes a goal from the db.  If the goal's underlying action is a limited
+ * use action then it will be deleted as well.
  *
  * @param $goal_id
  *   THe id of the goal to delete.
@@ -2767,18 +2768,25 @@ function personalize_visitor_actions_delete_action($action) {
  *   TRUE if the action subscribers cache needs to be rebuilt
  */
 function personalize_goal_delete($goal_id, $rebuild_subscribers = TRUE) {
-  if ($rebuild_subscribers) {
-    $action_name = db_select('personalize_campaign_goals', 'g')
-      ->fields('g', array('action'))
-      ->condition('id', $goal_id)
-      ->execute()
-      ->fetchField();
-  }
+  $action_name = db_select('personalize_campaign_goals', 'g')
+    ->fields('g', array('action'))
+    ->condition('id', $goal_id)
+    ->execute()
+    ->fetchField();
+
   // Delete the goal.
   db_delete('personalize_campaign_goals')
     ->condition('id', $goal_id)
     ->execute();
-  if (isset($action_name)) {
+
+  $action = visitor_actions_custom_load($action_name);
+  if ($action) {
+    // If the underlying action was a limited usage action, then delete it too.
+    if (!empty($action['limited_use'])) {
+      visitor_actions_delete_action($action_name);
+    }
+  }
+  if ($rebuild_subscribers) {
     // We only need to clear the subscribers cache if we no longer have
     // a goal that uses this action.
     $result = db_select('personalize_campaign_goals', 'g')

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -198,6 +198,8 @@ class PersonalizeBaseTest extends DrupalWebTestCase {
         return t('Save test');
       case 'delete':
         return t('Delete');
+      case 'delete_goal':
+        return t('Remove');
       case 'config':
         return t('Save configuration');
       case 'add_visitor_action':
@@ -2310,6 +2312,14 @@ class PersonalizeGoalAdminTest extends PersonalizeBaseTest {
     // The limited_use property should have been set via the form_alter.
     $action = visitor_actions_custom_load($action_name);
     $this->assertTrue($action['limited_use']);
+
+    // Now delete the goal and verify that the visitor action is also deleted.
+    $this->drupalGet("admin/structure/personalize/manage/{$machine_name}/edit");
+    $this->drupalPostAJAX(NULL, array(), array('edit-goals-0-remove' => $this->getButton('delete_goal')), NULL, array(), array(), 'personalize-agent-goals-form');
+    $goals = personalize_goal_load_by_conditions(array('agent' => $machine_name));
+    $this->assertEqual(count($goals), 0);
+    $action = visitor_actions_custom_load($action_name);
+    $this->assertTrue(empty($action));
 
     // Now create an agent that does not support goals.
     $agent_name = $this->randomName();

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -2314,12 +2314,39 @@ class PersonalizeGoalAdminTest extends PersonalizeBaseTest {
     $this->assertTrue($action['limited_use']);
 
     // Now delete the goal and verify that the visitor action is also deleted.
-    $this->drupalGet("admin/structure/personalize/manage/{$machine_name}/edit");
-    $this->drupalPostAJAX(NULL, array(), array('edit-goals-0-remove' => $this->getButton('delete_goal')), NULL, array(), array(), 'personalize-agent-goals-form');
+    $goal = reset($goals);
+    // It would be great to do this via AJAX submit, but the double-ajax submit
+    // on the same page doesn't seem to trigger properly in Simpletest.
+    personalize_goal_delete($goal->id);
     $goals = personalize_goal_load_by_conditions(array('agent' => $machine_name));
     $this->assertEqual(count($goals), 0);
     $action = visitor_actions_custom_load($action_name);
     $this->assertTrue(empty($action));
+
+    // Create another reusable goal and add it to the campaign.
+    $reusable_goal_name = $this->randomName();
+    $reusable_action_name = personalize_generate_machine_name($reusable_goal_name, 'visitor_actions_machine_name_exists', '_');
+    $edit = array(
+      'title' => $reusable_goal_name,
+      'machine_name' => $reusable_action_name,
+      'actionable_element' => 'page',
+      'event[page]' => 'client::view',
+      'pages' => '<front>',
+      'limited_use' => FALSE,
+    );
+    $this->drupalPost('admin/structure/visitor_actions/add', $edit, $this->getButton('add_visitor_action'));
+    $goals = personalize_goal_load_by_conditions(array('agent' => $machine_name));
+    $this->assertEqual(count($goals), 1);
+    $action = visitor_actions_custom_load($reusable_action_name);
+    // Now delete the goal and verify that the visitor action is also deleted.
+    $goal = reset($goals);
+    // It would be great to do this via AJAX submit, but the double-ajax submit
+    // on the same page doesn't seem to trigger properly in Simpletest.
+    personalize_goal_delete($goal->id);
+    $goals = personalize_goal_load_by_conditions(array('agent' => $machine_name));
+    $this->assertEqual(count($goals), 0);
+    $action = visitor_actions_custom_load($reusable_action_name);
+    $this->assertTrue(!empty($action));
 
     // Now create an agent that does not support goals.
     $agent_name = $this->randomName();


### PR DESCRIPTION
Update goal delete process to also delete the underlying action if it is of limited use. 
Clear the goals cache upon delete.
Pause a running campaign if all goals are deleted.
