### PR TITLE
Ch 2029: Generalize targeting functionality for non-Acquia Lift agents

### DIFF
--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -152,10 +152,12 @@ function personalize_blocks_form($form, &$form_state, $formtype, $pblock = NULL)
   // If the "Add another" button was clicked, we need to increment the number of
   // blocks by one.
   $num_blocks = count($pblock->options);
-  if (isset($form_state['num_blocks']) && $form_state['num_blocks'] > $num_blocks) {
+  $num_blocks_requested = isset($form_state['num_blocks']) ? $form_state['num_blocks'] : $num_blocks;
+  while ($num_blocks < $num_blocks_requested) {
     $pblock->options[] = array('option_label' => personalize_generate_option_label($num_blocks));
+    $num_blocks++;
   }
-  $form_state['num_blocks'] = count($pblock->options);
+  $form_state['num_blocks'] = $num_blocks;
   // Keep track of block options throughout Ajax submits.
   $form_state['pblock'] =  $pblock;
 
@@ -451,6 +453,9 @@ function personalize_blocks_form_validate($form, &$form_state) {
 
         if ($custom_block_exists) {
           form_set_error('blocks][' . $j . '][block][add][info', t('Ensure that each block description is unique.'));
+        }
+        else {
+          $num_blocks++;
         }
       }
       if (!empty($block['block']['bid'])) {

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -397,8 +397,10 @@ function personalize_elements_form_validate($form, &$form_state) {
     if ($changed) {
       drupal_set_message(t('Disallowed HTML tags were removed from @variations.', array('@variations' => format_plural($changed, '1 variation', '@count variations', array('@count' => $changed)))), 'warning');
     }
-    if ($values['pages_all'] == 0 && !personalize_elements_pages_validate($values['pages'])) {
-      form_set_error('pages', t('The selected pages must contain valid paths.'));
+    if ($values['pages_all'] == 0) {
+      $form['details']['pages']['#allow_external'] = FALSE;
+      $form['details']['pages']['#allow_dynamic'] = TRUE;
+      personalize_form_element_path_validate($form['details']['pages'], $form_state);
     }
 
     if (!personalize_elements_selector_validate($form_state['values']['selector'])) {
@@ -583,24 +585,4 @@ function personalize_elements_selector_validate($selector) {
   $matches = array();
   $matched = preg_match_all($re, $selector, $matches);
   return $matched == 0;
-}
-
-/**
- * Validates the pages entered for a personalized element.
- *
- * @param $pages
- *   The list of pages to validate separated by line breaks.
- * @return boolean
- *   True if the pages validate successfully, false if error.
- */
-function personalize_elements_pages_validate($pages) {
-  foreach(preg_split('~[\r\n]+~', $pages) as $line){
-    if(empty($line)) {
-      continue;
-    }
-    if (!valid_url($line) && $line !== '<front>') {
-      return FALSE;
-    }
-  }
-  return TRUE;
 }

--- a/modules/personalize_elements/tests/personalize_elements.test
+++ b/modules/personalize_elements/tests/personalize_elements.test
@@ -185,7 +185,7 @@ class PersonalizeElementsTest extends PersonalizeBaseTest {
     // entered.
     $edit = array(
       'pages_all' => 1,
-      'pages' => 'about',
+      'pages' => 'node',
     );
     $this->drupalPost("admin/structure/personalize/variations/personalize-elements/manage/{$option_set->osid}/edit", $edit, $this->getButton('save'));
     $this->drupalGet("admin/structure/personalize/variations/personalize-elements/manage/{$option_set->osid}/edit");
@@ -194,7 +194,7 @@ class PersonalizeElementsTest extends PersonalizeBaseTest {
     $edit['pages_all'] = 0;
     $this->drupalPost(NULL, $edit, $this->getButton('save'));
     $this->drupalGet("admin/structure/personalize/variations/personalize-elements/manage/{$option_set->osid}/edit");
-    $this->assertFieldByName('pages', 'about');
+    $this->assertFieldByName('pages', 'node');
 
     // Now edit  and specify '<front>' as the path.
     $edit = array(
@@ -207,7 +207,7 @@ class PersonalizeElementsTest extends PersonalizeBaseTest {
       'pages' => 'some invalid url',
     );
     $this->drupalPost("admin/structure/personalize/variations/personalize-elements/manage/{$option_set->osid}/edit", $edit, $this->getButton('save'));
-    $this->assertText('The selected pages must contain valid paths.');
+    $this->assertText('You have specified an invalid path for Pages');
   }
 
   /**

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -1129,6 +1129,25 @@ function personalize_campaign_wizard_validate_variations($form, &$form_state) {
 }
 
 /**
+ * Validation for advanced settings form for a particular option set.
+ *
+ * @param array $form_values
+ *   An array of form state values for each option set.
+ * @param string $parents
+ *   The string representation of the parents to the form values used to target
+ *   error messages, e.g. variations][option_sets][option_set_1]
+ */
+function personalize_campaign_wizard_validate_variations_advanced($form_values, $parents) {
+  if (!empty($form_values['advanced']['preview_link'])) {
+    if ($form_values['advanced']['preview_link'] != '<front>' && drupal_lookup_path('source', $form_values['advanced']['preview_link']) === FALSE) {
+      form_set_error($parents . '[advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
+        '@option_set' => $form_values['advanced']['label'],
+      )));
+    }
+  }
+}
+
+/**
  * Custom validation callback for scheduling form.
  */
 function personalize_campaign_wizard_validate_scheduling($form, &$form_state) {

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -1035,7 +1035,11 @@ function personalize_campaign_wizard_scheduling($form, &$form_state, $agent_data
  */
 function personalize_campaign_wizard_review($form, &$form_state, $agent_data, $agent_instance = NULL) {
   // Get the agent type specific options form.
-  $form['agent_options'] = $agent_instance->optionsForm($agent_data, array('agent_options', $agent_data->plugin));
+  $form['agent_options'] = array(
+    '#type' => 'container',
+    '#tree' => TRUE,
+  );
+  $form['agent_options']['options'] = $agent_instance::optionsForm($agent_data, array('agent_options', 'options'));
 
   // Add the advanced settings form.
   $form['advanced'] = array(
@@ -1233,7 +1237,7 @@ function personalize_campaign_wizard_validate_review($form, &$form_state) {
   ctools_include('plugins');
   if ($class = ctools_plugin_load_class('personalize', 'agent_type', $agent_data->plugin, 'handler')) {
     // Call the validation callback for the agent type.
-    $class::optionsFormValidate($form, $form_state);
+    $class::optionsFormValidate($form, $form_state, array('agent_options', 'options'));
   }
 }
 
@@ -1498,7 +1502,7 @@ function personalize_campaign_wizard_submit_scheduling($form, &$form_state, &$ag
  */
 function personalize_campaign_wizard_submit_review($form, &$form_state, &$agent_data) {
   // Agent-specific options
-  $agent_data->data = isset($form_state['values']['options'][$agent_data->plugin]) ? $form_state['values']['options'][$agent_data->plugin] : array();
+  $agent_data->data = isset($form_state['values']['agent_options']['options']) ? $form_state['values']['agent_options']['options'] : array();
 
   // Decision caching advanced setting.
   $agent_data->data['cache_decisions'] = $form_state['values']['cache_decisions'];

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -675,21 +675,15 @@ function personalize_campaign_wizard_targeting($form, &$form_state, $agent_data,
   );
 
   $section = &$form['targeting']['option_sets'];
-  // For any option sets that have been created for this campaign, display
-  // advanced options for specifying decision name etc.
   if (empty($option_sets)) {
     return $form;
   }
 
-  $targeting_support = FALSE;
-  if ($agent_instance instanceof PersonalizeExplicitTargetingInterface) {
-    $targeting_support = $agent_instance->explicitTargetingSupportMultiple();
-    // Build up a list of targeting values so we can map options to them.
-    $targeting_values = personalize_get_targeting_values_for_agent($agent_data);
-  }
+  $targeting_support = $agent_instance->explicitTargetingSupportMultiple();
+  // Build up a list of targeting values so we can map options to them.
+  $targeting_values = personalize_get_targeting_values_for_agent($agent_data);
 
   foreach ($option_sets as $option_set) {
-    $option_set_plugin = personalize_get_option_set_type($option_set->plugin);
     $replace_option_set_id = 'personalize-option-set-' . $option_set->osid;
 
     // Show this open if it was just refreshed via Ajax.
@@ -719,7 +713,7 @@ function personalize_campaign_wizard_targeting($form, &$form_state, $agent_data,
     $variant_number = 1;
     $targeting = personalize_get_targeting_for_options($option_set);
     foreach ($option_set->options as $option) {
-      // Determine container classes based on campaign status and winner.
+      // Determine container classes based on campaign status.
       $classes = array('personalize-admin-content-item', 'personalize-content-variation', 'clearfix');
       if ($is_running) {
         $classes[] = 'personalize-content-variation-running';

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -1030,32 +1030,7 @@ function personalize_campaign_wizard_scheduling($form, &$form_state, $agent_data
  */
 function personalize_campaign_wizard_review($form, &$form_state, $agent_data, $agent_instance = NULL) {
   // Get the agent type specific options form.
-  $agent_types = personalize_get_agent_types();
-  foreach ($agent_types as $name => $info) {
-    if ($class = ctools_plugin_load_class('personalize', 'agent_type', $name, 'handler')) {
-      // Form structure for option parents in the current form.
-      $option_parents = array('options', $name);
-      // Get the agent type's options form elements
-      $agent_type_form_options[$name] = call_user_func_array(array($class, 'optionsForm'), array($agent_data, $option_parents));
-    }
-  }
-
-  // Add the agent-type-specific form elements to the form, to be shown only if the
-  // agent type in question is selected.
-  $form['options'] = array('#tree' => TRUE);
-  if (!empty($agent_data->plugin)) {
-    // If in edit mode, then only show the options for the selected agent.
-    $form['options'][$agent_data->plugin] = $agent_type_form_options[$agent_data->plugin];
-  }
-  else {
-    // If in add mode, then show options dynamically using states.
-    foreach ($agent_type_form_options as $agent_type => $options) {
-      foreach ($options as &$option) {
-        $option['#states'] = array('visible' => array(':input[name="agent_basic_info[agent_type]"]' => array('value' => $agent_type)));
-      }
-      $form['options'][$agent_type] = $options;
-    }
-  }
+  $form['agent_options'] = $agent_instance->optionsForm($agent_data, array('agent_options', $agent_data->plugin));
 
   // Add the advanced settings form.
   $form['advanced'] = array(
@@ -1249,9 +1224,9 @@ function personalize_campaign_wizard_validate_scheduling($form, &$form_state) {
  * Custom validation callback for details form.
  */
 function personalize_campaign_wizard_validate_review($form, &$form_state) {
-  $agent_type = $form_state['values']['agent_basic_info']['agent_type'];
+  $agent_data = $form['#agent'];
   ctools_include('plugins');
-  if ($class = ctools_plugin_load_class('personalize', 'agent_type', $agent_type, 'handler')) {
+  if ($class = ctools_plugin_load_class('personalize', 'agent_type', $agent_data->plugin, 'handler')) {
     // Call the validation callback for the agent type.
     $class::optionsFormValidate($form, $form_state);
   }

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -22,10 +22,6 @@ function personalize_campaign_wizard($form, &$form_state, $agent_data = NULL, $s
   // Set the default step.
   $selected = empty($selected) ? 'variations' : $selected;
 
-  // Read the current step from the parameters unless the form process has
-  // already started.
-  $form_state['storage']['step'] = isset($form_state['storage']['step']) ? $form_state['storage']['step'] : $selected;
-
   // Determine the data for the current campaign.
   if (empty($agent_data)) {
     if (isset($form_state['values']['agent'])) {
@@ -47,6 +43,16 @@ function personalize_campaign_wizard($form, &$form_state, $agent_data = NULL, $s
   }
   $form['#agent'] = $agent_data;
   $agent_instance = !empty($agent_data->machine_name) ? personalize_agent_load_agent($agent_data->machine_name) : NULL;
+
+  // Read the current step from the parameters unless the form process has
+  // already started.
+  $current_step = isset($form_state['storage']['step']) ? $form_state['storage']['step'] : $selected;
+  // Make sure that the current step requested is applicable to the agent.
+  $agent_steps = _personalize_campaign_wizard_steps($agent_instance);
+  if (empty($agent_steps[$current_step])) {
+    $current_step = 'variations';
+  }
+  $form_state['storage']['step'] = $current_step;
 
   $form['#attached']['library'][] = array('personalize', 'admin.campaign');
 
@@ -115,26 +121,7 @@ function personalize_campaign_wizard_process_bar($form, &$form_state, $agent_dat
     '#attributes' => array(
       'class' => array('personalize-wizard-navigation'),
     ),
-    '#options' => array(
-      'variations' => array(
-        'label' => t('What'),
-      ),
-      'goals' => array(
-        'label' => t('Why'),
-      ),
-      'targeting' => array(
-        'label' => t('Who'),
-      ),
-      'scheduling' => array(
-        'label' => t('When'),
-      ),
-      'review' => array(
-        'label' => t('Review'),
-      ),
-      'report' => array(
-        'label' => t('Outcome'),
-      ),
-    ),
+    '#options' => _personalize_campaign_wizard_steps($agent_instance),
   );
 
   // Disable all options when creating a campaign for the first time.
@@ -206,27 +193,14 @@ function personalize_campaign_wizard_action($form, &$form_state, $agent_data, $a
   $not_running = $status == PERSONALIZE_STATUS_NOT_STARTED || $status == PERSONALIZE_STATUS_PAUSED;
   $scheduled = personalize_agent_get_start_date($agent_data->machine_name) > 0;
 
-  switch ($form_state['storage']['step']) {
-    case 'variations':
-      $message = t('Goals for these variations');
-      break;
-    case 'goals':
-      $message = t('Who\'s going to see what');
-      break;
-    case 'targeting':
-      $message = t('When should this campaign run');
-      break;
-    case 'scheduling':
-      $message = $not_running ? t('Review personalization settings') : t('Review personalization results');
-      break;
-    case 'review':
-      $button_value = $not_running && !$scheduled ? t('Start') : t('Save');
-      break;
-    case 'report':
-      $button_value = '';
-      break;
-  }
-  if (empty($button_value)) {
+  // Determine the preview text to show with the button based on the next step
+  // for this agent instance.
+  $steps = _personalize_campaign_wizard_steps($agent_instance);
+  $next_step = _personalize_campaign_wizard_next_step($form_state['storage']['step'], $agent_instance);
+  $current_info = $steps[$form_state['storage']['step']];
+  $next_info = $steps[$next_step];
+
+  if (empty($next_info) || empty($current_info['button_value'])) {
     return $form;
   }
 
@@ -238,8 +212,8 @@ function personalize_campaign_wizard_action($form, &$form_state, $agent_data, $a
   $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#name' => 'wizard_submit',
-    '#value' => $button_value,
-    '#suffix' => $message,
+    '#value' => $current_info['button_value'],
+    '#suffix' => empty($next_info['preview_message']) ? '' : $next_info['preview_message'],
   );
 
   return $form;
@@ -690,6 +664,11 @@ function personalize_campaign_wizard_variations_advanced(&$form, &$form_state, $
  *   The agent that defines the functionality for the campaign (if set).
  */
 function personalize_campaign_wizard_targeting($form, &$form_state, $agent_data, $agent_instance = NULL) {
+  if (empty($agent_instance) || (!($agent_instance instanceof PersonalizeExplicitTargetingInterface) && !($agent_instance instanceof PersonalizeAutoTargetingInterface))) {
+    return array(
+      '#markup' => t('This agent does not support targeting.'),
+    );
+  }
   // Add visitor context items to the form for agents that support automatic
   // targeting.
   if (!empty($agent_instance) && $agent_instance instanceof PersonalizeAutoTargetingInterface) {
@@ -716,6 +695,11 @@ function personalize_campaign_wizard_targeting($form, &$form_state, $agent_data,
  *   The agent that defines the functionality for the campaign (if set).
  */
 function personalize_campaign_wizard_goals($form, &$form_state, $agent_data, $agent_instance = NULL) {
+  if (empty($agent_instance) || !($agent_instance instanceof PersonalizeAgentGoalInterface)) {
+    return array(
+      '#markup' => t('This agent does not support goals.'),
+    );
+  }
   $goal_entities = personalize_goal_load_by_conditions(array('agent' => $agent_data->machine_name));
   $goals = $exclude = array();
   $all_actions = visitor_actions_get_actions();
@@ -1193,9 +1177,6 @@ function personalize_campaign_wizard_submit($form, &$form_state) {
   }
 
   // Call the submit handler that is specific to the current step.
-  // Each step submit handler is responsible for setting the
-  // $form_state['new_step'] value to the appropriate next step.
-  $form_state['new_step'] = 'review';
   $function = 'personalize_campaign_wizard_submit_' . $form_state['storage']['step'];
   if (function_exists($function)) {
     $function($form, $form_state, $agent);
@@ -1215,7 +1196,9 @@ function personalize_campaign_wizard_submit($form, &$form_state) {
   }
 
   // Rebuild the form to show the next step.
-  $form_state['storage']['step'] = $form_state['new_step'];
+  $agent_instance = personalize_agent_load_agent($agent);
+
+  $form_state['storage']['step'] = _personalize_campaign_wizard_next_step($form_state['storage']['step'], $agent_instance);
   $form_state['rebuild'] = TRUE;
 }
 
@@ -1331,7 +1314,6 @@ function personalize_campaign_wizard_submit_variations($form, &$form_state, &$ag
       personalize_option_set_save($option_set);
     }
   }
-  $form_state['new_step'] = 'targeting';
 }
 
 /**
@@ -1368,8 +1350,6 @@ function personalize_campaign_wizard_submit_targeting($form, &$form_state, &$age
     $visitor_context = personalize_admin_convert_visitor_context_form_values($form_state['values']['visitor_context']);
   }
   $agent_data->data['visitor_context'] = $visitor_context;
-
-  $form_state['new_step'] = 'scheduling';
 }
 
 /**
@@ -1409,7 +1389,6 @@ function personalize_campaign_wizard_submit_goals($form, &$form_state, &$agent_d
   }
   // Redraw the form without any additional new goals included.
   unset($form_state['num_goals']);
-  $form_state['new_step'] = 'targeting';
 }
 
 /**
@@ -1417,9 +1396,6 @@ function personalize_campaign_wizard_submit_goals($form, &$form_state, &$agent_d
  */
 function personalize_campaign_wizard_submit_scheduling($form, &$form_state, &$agent_data) {
   personalize_agent_date_form_submit($agent_data->machine_name, $form_state['values']);
-
-  // Since this is the last step, just return to the start of the wizard.
-  $form_state['new_step'] = 'review';
 }
 
 /**
@@ -1431,4 +1407,85 @@ function personalize_campaign_wizard_submit_review($form, &$form_state, &$agent_
 
   // Decision caching advanced setting.
   $agent_data->data['cache_decisions'] = $form_state['values']['cache_decisions'];
+}
+
+/**
+ ********************************************************************
+ *
+ * H E L P E R  F U N C T I O N S
+ *
+ ********************************************************************
+ */
+
+/**
+ * Generate an array of steps for the wizard based on the type of agent shown.
+ *
+ * @param stdClass $agent_instance
+ *   (Optional) The agent instance for the current agent.
+ * @return array
+ *   An array of steps.
+ */
+function _personalize_campaign_wizard_steps(PersonalizeAgentInterface $agent_instance = NULL) {
+  $status = empty($agent_instance) ? PERSONALIZE_STATUS_NOT_STARTED : personalize_agent_get_status($agent_instance->getMachineName());
+  $not_running = $status == PERSONALIZE_STATUS_NOT_STARTED || $status == PERSONALIZE_STATUS_PAUSED;
+  $scheduled = !empty($agent_instance) && personalize_agent_get_start_date($agent_instance->getMachineName()) > 0;
+
+  $next = t('Next');
+  $message = '';
+  $steps = array(
+    'variations' => array(
+      'label' => t('What'),
+      'button_value' => $next,
+    ),
+    'goals' => array(
+      'label' => t('Why'),
+      'button_value' => $next,
+      'preview_message' => t('Goals for these variations'),
+    ),
+    'targeting' => array(
+      'label' => t('Who'),
+      'button_value' => $next,
+      'preview_message' => t('Who\'s going to see what'),
+    ),
+    'scheduling' => array(
+      'label' => t('When'),
+      'button_value' => $next,
+      'preview_message' => t('When should this campaign run'),
+    ),
+    'review' => array(
+      'label' => t('Review'),
+      'button_value' => $not_running && !$scheduled ? t('Start') : t('Save'),
+      'preview_message' => $not_running ? t('Review personalization settings') : t('Review personalization results')
+    ),
+    'report' => array(
+      'label' => t('Outcome'),
+      'button_value' => $next,
+    )
+  );
+  // Remove any steps that aren't applicable to the current agent.
+  if (empty($agent_instance) || !($agent_instance instanceof PersonalizeAgentGoalInterface)) {
+    unset($steps['goals']);
+  }
+  if (empty($agent_instance) || (!($agent_instance instanceof PersonalizeAutoTargetingInterface) && !($agent_instance instanceof PersonalizeExplicitTargetingInterface))) {
+    unset($steps['targeting']);
+  }
+  return $steps;
+}
+
+/**
+ * Determine the next step in the wizard based on the type of agent shown.
+ *
+ * @param string $current_step
+ *   The current step key.
+ * @param stdClass $agent_instance
+ *   The agent instance for the current agent.
+ * @return string
+ *   The next step if there is a further step.  If the current step is the last
+ *   step then it is returned.
+ */
+function _personalize_campaign_wizard_next_step($current_step, PersonalizeAgentInterface $agent_instance) {
+  $agent_steps = array_keys(_personalize_campaign_wizard_steps($agent_instance));
+  $index = array_search($current_step, $agent_steps);
+  $index++;
+  return $index < count($agent_steps) ? $agent_steps[$index] : $current_step;
 }

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -153,6 +153,11 @@ function personalize_campaign_wizard_process_bar($form, &$form_state, $agent_dat
       'class' => array('personalize-wizard-process-bar-actions'),
     ),
   );
+  // Save the current subform.
+  $form['process_bar']['actions']['save'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save'),
+  );
   // Change campaign status.
   if (!empty($agent_data->machine_name)) {
     $agent_status = personalize_agent_get_status($agent_data->machine_name);
@@ -198,7 +203,7 @@ function personalize_campaign_wizard_action($form, &$form_state, $agent_data, $a
   // Determine the preview text to show with the button based on the next step
   // for this agent instance.
   $steps = _personalize_campaign_wizard_steps($agent_instance);
-  $next_step = _personalize_campaign_wizard_next_step($form_state['storage']['step'], $agent_instance);
+  $next_step = _personalize_campaign_wizard_next_step($form_state, $agent_instance);
   $current_info = $steps[$form_state['storage']['step']];
   $next_info = $steps[$next_step];
 
@@ -1278,7 +1283,7 @@ function personalize_campaign_wizard_submit($form, &$form_state) {
   // Rebuild the form to show the next step.
   $agent_instance = personalize_agent_load_agent($agent->machine_name);
 
-  $form_state['storage']['step'] = _personalize_campaign_wizard_next_step($form_state['storage']['step'], $agent_instance);
+  $form_state['storage']['step'] = _personalize_campaign_wizard_next_step($form_state, $agent_instance);
   $form_state['rebuild'] = TRUE;
 }
 
@@ -1565,17 +1570,23 @@ function _personalize_campaign_wizard_steps(PersonalizeAgentInterface $agent_ins
 /**
  * Determine the next step in the wizard based on the type of agent shown.
  *
- * @param string $current_step
- *   The current step key.
+ * @param array $form_state
+ *   The current form state.
  * @param stdClass $agent_instance
  *   The agent instance for the current agent.
  * @return string
  *   The next step if there is a further step.  If the current step is the last
  *   step then it is returned.
  */
-function _personalize_campaign_wizard_next_step($current_step, PersonalizeAgentInterface $agent_instance) {
+function _personalize_campaign_wizard_next_step($form_state, PersonalizeAgentInterface $agent_instance) {
+  // If the user is just clicking the standard "save" button then they should
+  // stay on the same sub-form.
+  if ($form_state['triggering_element']['#value'] === t('Save')) {
+    return $form_state['storage']['step'];
+  }
+  // Determine the next step to show based on the steps available to this agent.
   $agent_steps = array_keys(_personalize_campaign_wizard_steps($agent_instance));
-  $index = array_search($current_step, $agent_steps);
+  $index = array_search($form_state['storage']['step'], $agent_steps);
   $index++;
-  return $index < count($agent_steps) ? $agent_steps[$index] : $current_step;
+  return $index < count($agent_steps) ? $agent_steps[$index] : $form_state['storage']['step'];
 }

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -1585,7 +1585,7 @@ function _personalize_campaign_wizard_steps(PersonalizeAgentInterface $agent_ins
 function _personalize_campaign_wizard_next_step($form_state, PersonalizeAgentInterface $agent_instance) {
   // If the user is just clicking the standard "save" button then they should
   // stay on the same sub-form.
-  if ($form_state['triggering_element']['#value'] === t('Save')) {
+  if (isset($form_state['triggering_element']) && $form_state['triggering_element']['#value'] === t('Save')) {
     return $form_state['storage']['step'];
   }
   // Determine the next step to show based on the steps available to this agent.

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -19,6 +19,13 @@
 function personalize_campaign_wizard($form, &$form_state, $agent_data = NULL, $selected = NULL) {
   module_load_include('inc', 'personalize', 'personalize.admin');
 
+  // We have to specify the include file so as not to lose it during rendering from ajax.
+  // @see personalize_agent_form_ajax_submit()
+  // @see drupal_retrieve_form():734
+  $form_state['build_info']['files'] = array(
+    drupal_get_path('module', 'personalize') . '/personalize.admin.campaign.inc',
+  );
+
   // Set the default step.
   $selected = empty($selected) ? 'variations' : $selected;
 
@@ -47,10 +54,12 @@ function personalize_campaign_wizard($form, &$form_state, $agent_data = NULL, $s
   // Read the current step from the parameters unless the form process has
   // already started.
   $current_step = isset($form_state['storage']['step']) ? $form_state['storage']['step'] : $selected;
-  // Make sure that the current step requested is applicable to the agent.
-  $agent_steps = _personalize_campaign_wizard_steps($agent_instance);
-  if (empty($agent_steps[$current_step])) {
-    $current_step = 'variations';
+  if ($current_step !== 'base') {
+    // Make sure that the current step requested is applicable to the agent.
+    $agent_steps = _personalize_campaign_wizard_steps($agent_instance);
+    if (empty($agent_steps[$current_step])) {
+      $current_step = 'variations';
+    }
   }
   $form_state['storage']['step'] = $current_step;
 
@@ -186,13 +195,6 @@ function personalize_campaign_wizard_process_bar($form, &$form_state, $agent_dat
  *   The form array for the actions of the multi-step form.
  */
 function personalize_campaign_wizard_action($form, &$form_state, $agent_data, $agent_instance) {
-
-  $status = empty($agent_data->machine_name) ? PERSONALIZE_STATUS_NOT_STARTED : personalize_agent_get_status($agent_data->machine_name);
-  $button_value = t('Next');
-  $message = '';
-  $not_running = $status == PERSONALIZE_STATUS_NOT_STARTED || $status == PERSONALIZE_STATUS_PAUSED;
-  $scheduled = personalize_agent_get_start_date($agent_data->machine_name) > 0;
-
   // Determine the preview text to show with the button based on the next step
   // for this agent instance.
   $steps = _personalize_campaign_wizard_steps($agent_instance);
@@ -397,13 +399,6 @@ function personalize_campaign_wizard_variations($form, &$form_state, $agent_data
     return $form;
   }
 
-  $targeting_support = FALSE;
-  if ($agent_instance instanceof PersonalizeExplicitTargetingInterface) {
-    $targeting_support = $agent_instance->explicitTargetingSupportMultiple();
-    // Build up a list of targeting values so we can map options to them.
-    $targeting_values = personalize_get_targeting_values_for_agent($agent_data);
-  }
-
   foreach ($option_sets as $option_set) {
     $option_set_plugin = personalize_get_option_set_type($option_set->plugin);
     $replace_option_set_id = 'personalize-option-set-' . $option_set->osid;
@@ -521,45 +516,9 @@ function personalize_campaign_wizard_variations($form, &$form_state, $agent_data
           ),
         );
       }
-      if ($targeting_support && !empty($targeting_values)) {
-        $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['targeting'] = array(
-          '#type' => 'container',
-          '#attributes' => array(
-            'class' => array('personalize-variation-row'),
-          ),
-        );
-        $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['targeting']['enable_explicit_targeting'] = array(
-          '#title' => t('Show to visitors with specific traits'),
-          '#type' => 'checkbox',
-          '#default_value' => !empty($targeting[$option['option_id']]) ? 1 : 0,
-          '#parents' => array('option_sets', 'option_set_' . $option_set->osid, 'options', $option['option_id'],'enable_explicit_targeting'),
-        );
-        $states = array(
-          'visible' => array(
-            ':input[name="option_sets[option_set_' . $option_set->osid . '][options][' . $option['option_id'] . '][enable_explicit_targeting]"]' => array('checked' => TRUE),
-          ),
-        );
-        $parents = array('option_sets', 'option_set_' . $option_set->osid, 'options', $option['option_id']);
-        $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['explicit_targeting'] = personalize_targeting_support_form_elements($option_set, $option, $targeting_values, $targeting_support, $states, $parents, $form_state);
-      }
       $variant_number++;
     } // end of loop through variations.
 
-    switch ($targeting_support) {
-      case PersonalizeExplicitTargetingInterface::EXPLICIT_TARGETING_MULTIPLE_AND:
-        $section['option_set_' . $option_set->osid]['explicit_targeting_explanation'] = array(
-          '#type' => 'markup',
-          '#markup' => t('You can add explicit targeting for this content variation. If you choose multiple contexts for an option, then the visitor must have all specified contexts for the rule to apply.')
-
-        );
-        break;
-      case PersonalizeExplicitTargetingInterface::EXPLICIT_TARGETING_MULTIPLE_OR:
-        $section['option_set_' . $option_set->osid]['explicit_targeting_explanation'] = array(
-          '#type' => 'markup',
-          '#markup' => t('You can add explicit targeting for this content variation. If you choose multiple contexts for an option, then the rule will apply if the visitor has any of the specified contexts.')
-        );
-        break;
-    }
     // Add the advanced options.
     $section['option_set_' . $option_set->osid]['advanced'] = personalize_campaign_wizard_variations_advanced($form, $form_state, $option_set);
   } // End loop through option sets.
@@ -669,15 +628,165 @@ function personalize_campaign_wizard_targeting($form, &$form_state, $agent_data,
       '#markup' => t('This agent does not support targeting.'),
     );
   }
+
+  $form['targeting'] = array(
+    '#type' => 'container',
+    '#tree' => FALSE,
+    '#attributes' => array(
+      'class' => array('personalize-wizard-section'),
+    ),
+  );
+  $form['targeting']['title'] = array(
+    '#type' => 'container',
+    '#title' => t('Targeting'),
+    '#theme' => 'personalize_wizard_section_title',
+  );
+
   // Add visitor context items to the form for agents that support automatic
   // targeting.
-  if (!empty($agent_instance) && $agent_instance instanceof PersonalizeAutoTargetingInterface) {
+  if ($agent_instance instanceof PersonalizeAutoTargetingInterface) {
     $visitor_context = isset($agent_data->data['visitor_context']) ? $agent_data->data['visitor_context'] : array();
     if ($context_element = personalize_admin_build_visitor_context_select($visitor_context, TRUE, $agent_data)) {
-      $form['visitor_context'] = $context_element;
+      $form['targeting']['visitor_context'] = $context_element;
     }
   }
 
+  if (!($agent_instance instanceof PersonalizeExplicitTargetingInterface)) {
+    // The rest of this function applies to explicit targeting.
+    return $form;
+  }
+
+  // Load the data used throughout form.
+  $option_sets = personalize_option_set_load_by_agent($agent_data->machine_name);
+  $is_running = personalize_agent_get_status($agent_data->machine_name) == PERSONALIZE_STATUS_RUNNING;
+
+  // Containing element for all option sets.
+  $form['targeting']['option_sets'] = array(
+    '#tree' => TRUE,
+    '#type' => 'container',
+    '#attributes' => array(
+      'class' => array('personalize-wizard-variation-sets'),
+    ),
+  );
+
+  $section = &$form['targeting']['option_sets'];
+  // For any option sets that have been created for this campaign, display
+  // advanced options for specifying decision name etc.
+  if (empty($option_sets)) {
+    return $form;
+  }
+
+  $targeting_support = FALSE;
+  if ($agent_instance instanceof PersonalizeExplicitTargetingInterface) {
+    $targeting_support = $agent_instance->explicitTargetingSupportMultiple();
+    // Build up a list of targeting values so we can map options to them.
+    $targeting_values = personalize_get_targeting_values_for_agent($agent_data);
+  }
+
+  foreach ($option_sets as $option_set) {
+    $option_set_plugin = personalize_get_option_set_type($option_set->plugin);
+    $replace_option_set_id = 'personalize-option-set-' . $option_set->osid;
+
+    // Show this open if it was just refreshed via Ajax.
+    $section['option_set_' . $option_set->osid] = array(
+      '#tree' => TRUE,
+      '#type' => 'container',
+      '#attributes' => array(
+        'class' => array('personalize-option-set'),
+        'id' => $replace_option_set_id, // Used for AJAX replace.
+      ),
+    );
+    $option_set_winner = isset($form_state['winners']['option_set_' . $option_set->osid]) ? $form_state['winners']['option_set_' . $option_set->osid] : $option_set->winner;
+    $section['option_set_' . $option_set->osid]['winner'] = array(
+      '#type' => 'value',
+      '#value' => $option_set_winner,
+    );
+    // Header information.
+    $section['option_set_' . $option_set->osid]['summary'] = array(
+      '#type' => 'markup',
+      '#markup' => theme('personalize_wizard_variations_header', array(
+        'variation_title' => $option_set->label,
+        'variation_count' => count($option_set->options),
+      )),
+      '#theme_wrappers' => array('container'),
+    );
+
+    $variant_number = 1;
+    $targeting = personalize_get_targeting_for_options($option_set);
+    foreach ($option_set->options as $option) {
+      // Determine container classes based on campaign status and winner.
+      $classes = array('personalize-admin-content-item', 'personalize-content-variation', 'clearfix');
+      if ($is_running) {
+        $classes[] = 'personalize-content-variation-running';
+      }
+      else {
+        $classes[] = 'personalize-content-variation-stopped';
+      }
+      $section['option_set_' . $option_set->osid]['options'][$option['option_id']] = array(
+        '#tree' => TRUE,
+        '#type' => 'container',
+        '#attributes' => array(
+          'class' => $classes,
+        ),
+      );
+      $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['basic'] = array(
+        '#type' => 'container',
+        '#attributes' => array(
+          'class' => array('personalize-variation-row'),
+        ),
+      );
+
+      $heading = theme('personalize_admin_enumerated_item', array(
+        'enum' => t('V@delta', array('@delta' => $variant_number)),
+        'title' => check_plain($option['option_label']),
+        'title_prefix' => '"',
+        'title_suffix' => '"',
+      ));
+      $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['basic']['heading'] = array(
+        '#markup' => $heading,
+      );
+      if ($targeting_support && !empty($targeting_values)) {
+        $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['targeting'] = array(
+          '#type' => 'container',
+          '#attributes' => array(
+            'class' => array('personalize-variation-row'),
+          ),
+        );
+        $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['targeting']['enable_explicit_targeting'] = array(
+          '#title' => t('Show to visitors with specific traits'),
+          '#type' => 'checkbox',
+          '#default_value' => !empty($targeting[$option['option_id']]) ? 1 : 0,
+          '#parents' => array('option_sets', 'option_set_' . $option_set->osid, 'options', $option['option_id'],'enable_explicit_targeting'),
+        );
+        $states = array(
+          'visible' => array(
+            ':input[name="option_sets[option_set_' . $option_set->osid . '][options][' . $option['option_id'] . '][enable_explicit_targeting]"]' => array('checked' => TRUE),
+          ),
+        );
+        $parents = array('option_sets', 'option_set_' . $option_set->osid, 'options', $option['option_id']);
+        $section['option_set_' . $option_set->osid]['options'][$option['option_id']]['explicit_targeting'] = personalize_targeting_support_form_elements($option_set, $option, $targeting_values, $targeting_support, $states, $parents, $form_state);
+      }
+      $variant_number++;
+    } // end of loop through variations.
+
+    switch ($targeting_support) {
+      case PersonalizeExplicitTargetingInterface::EXPLICIT_TARGETING_MULTIPLE_AND:
+        $section['option_set_' . $option_set->osid]['explicit_targeting_explanation'] = array(
+          '#type' => 'markup',
+          '#markup' => t('You can add explicit targeting for this content variation. If you choose multiple contexts for an option, then the visitor must have all specified contexts for the rule to apply.')
+
+        );
+        break;
+      case PersonalizeExplicitTargetingInterface::EXPLICIT_TARGETING_MULTIPLE_OR:
+        $section['option_set_' . $option_set->osid]['explicit_targeting_explanation'] = array(
+          '#type' => 'markup',
+          '#markup' => t('You can add explicit targeting for this content variation. If you choose multiple contexts for an option, then the rule will apply if the visitor has any of the specified contexts.')
+        );
+        break;
+    }
+    // Add the advanced options.
+    $section['option_set_' . $option_set->osid]['advanced'] = personalize_campaign_wizard_variations_advanced($form, $form_state, $option_set);
+  } // End loop through option sets.
   return $form;
 }
 
@@ -1083,13 +1192,10 @@ function personalize_campaign_wizard_validate($form, &$form_state) {
 }
 
 /**
- * Custom validation callback for variations form.
- *
- * Clean Explicit targeting if "Enable explicit targeting" is unchecked.
- * Ensure that preview links are internal and valid.
+ * Validation callback for targeting form.
  */
-function personalize_campaign_wizard_validate_variations($form, &$form_state) {
-  $form_values = &$form_state['values']['option_sets'];
+function personalize_campaign_wizard_validate_targeting($form, &$form_state) {
+  $form_values = &$form_state['values']['targeting'];
   if (empty($form_values)) {
     return;
   }
@@ -1110,6 +1216,7 @@ function personalize_campaign_wizard_validate_variations($form, &$form_state) {
   if ($need_form_state_cache_clear) {
     cache_clear_all('form_state_' . $form_state['values']['form_build_id'], 'cache_form');
   }
+
 }
 
 /**
@@ -1169,10 +1276,8 @@ function personalize_campaign_wizard_submit($form, &$form_state) {
   $agent = personalize_campaign_wizard_submit_base($form, $form_state);
   personalize_set_campaign_context($agent->machine_name);
   if ($form_state['storage']['step'] === 'base') {
-    // Nothing left to do except start with the variations process.
-    $form_state['storage']['step'] = 'variations';
-    $form_state['values']['agent'] = $agent->machine_name;
-    $form_state['rebuild'] = TRUE;
+    // Redirect to the full wizard view with variations selected.
+    $form_state['redirect'] = 'admin/structure/personalize/manage/' . $agent->machine_name . '/variations';
     return;
   }
 
@@ -1196,7 +1301,7 @@ function personalize_campaign_wizard_submit($form, &$form_state) {
   }
 
   // Rebuild the form to show the next step.
-  $agent_instance = personalize_agent_load_agent($agent);
+  $agent_instance = personalize_agent_load_agent($agent->machine_name);
 
   $form_state['storage']['step'] = _personalize_campaign_wizard_next_step($form_state['storage']['step'], $agent_instance);
   $form_state['rebuild'] = TRUE;
@@ -1228,8 +1333,7 @@ function personalize_campaign_wizard_submit_base($form, &$form_state) {
  * Submit handler for the variations section.
  */
 function personalize_campaign_wizard_submit_variations($form, &$form_state, &$agent_data) {
-  $agent_instance = personalize_agent_load_agent($agent_data->machine_name);
-  $form_values = is_array($form_state['values']['option_sets']) ? $form_state['values']['option_sets'] : array();
+  $form_values = isset($form_state['values']['option_sets']) && is_array($form_state['values']['option_sets']) ? $form_state['values']['option_sets'] : array();
   foreach ($form_values as $option_set_id => $values) {
     $osid = (int) str_replace('option_set_', '', $option_set_id);
     if ($option_set = personalize_option_set_load($osid)) {
@@ -1252,65 +1356,6 @@ function personalize_campaign_wizard_submit_variations($form, &$form_state, &$ag
         personalize_option_set_save($option_set);
         continue;
       }
-
-      // Keep track of which explicit targeting features have already been
-      // designated as each can only be specified for one option.
-      // Keep track of feature strings that have already been designated to options,
-      // which options they have been designated to, and whether there's a rule
-      // associated with each feature.
-      $designated_features = $targeting = array();
-      $target_weight = 0;
-      foreach ($values['options'] as $option_id => $settings) {
-        $option_features[$option_id] = $feature_rules[$option_id] = array();
-        $feature_values = $rules = array();
-        if (isset($settings['explicit_targeting']) && !empty($settings['explicit_targeting']['mapping'])) {
-          foreach ($settings['explicit_targeting']['mapping']['contexts'] as $delta => $context_values) {
-            if ($context_values['context'] == '') {
-              continue;
-            }
-            list($plugin_name, $context_name) = explode(PERSONALIZE_TARGETING_ADMIN_SEPARATOR, $context_values['context']);
-            $context_values['match'] = $context_values['value']['match'];
-            $context_values['operator'] = $context_values['value']['operator'];
-            unset($context_values['value'], $context_values['remove']);
-            // Generate a value code based on the operator used.
-            $value = personalize_targeting_generate_value_code($context_values['match'], $context_values['operator']);
-            // Create a feature string for this context value that can be consumed
-            // by the agent that will be using it.
-            $feature_string = $agent_instance->convertContextToFeatureString($context_name, $value);
-            $feature_values[] = $feature_string;
-            // Save the actual rule information as this is what will be used
-            // for evaluating it.
-            $rules[$feature_string] = $context_values;
-            // Override the context to split it into plugin and context parts.
-            $rules[$feature_string]['context'] = $context_name;
-            $rules[$feature_string]['plugin'] = $plugin_name;
-          }
-          foreach ($feature_values as $feature) {
-            // Mark this feature string as already designated.
-            if (!in_array($feature, $designated_features)) {
-              $designated_features[] = $feature;
-            }
-            else {
-              drupal_set_message(t('You have set the same targeting feature for more than one option. Depending on whether features are AND\'d or OR\'d together for the different options, and on how the decision agent evaluates explicit targeting rules, this may not produce the desired effect.'), 'warning');
-            }
-          }
-          $rule = array(
-            'option_id' => $option_id,
-            'targeting_features' => $feature_values,
-            'targeting_rules' => $rules,
-            'weight' => $target_weight,
-          );
-          // If a strategy has been specified for how to use the targeting features,
-          // then store this as well.
-          if (isset($values['options'][$option_id]['explicit_targeting']['strategy'])) {
-            $rule['targeting_strategy'] = $values['options'][$option_id]['explicit_targeting']['strategy'];
-          }
-          $targeting['target_' . ($target_weight+1)] = $rule;
-          $target_weight++;
-        }
-      }
-
-      $option_set->targeting = $targeting;
       personalize_option_set_save($option_set);
     }
   }
@@ -1350,6 +1395,76 @@ function personalize_campaign_wizard_submit_targeting($form, &$form_state, &$age
     $visitor_context = personalize_admin_convert_visitor_context_form_values($form_state['values']['visitor_context']);
   }
   $agent_data->data['visitor_context'] = $visitor_context;
+  $agent_instance = personalize_agent_load_agent($agent_data->machine_name);
+  $form_values = isset($form_state['values']['option_sets']) && is_array($form_state['values']['option_sets']) ? $form_state['values']['option_sets'] : array();
+  foreach ($form_values as $option_set_id => $values) {
+    $osid = (int) str_replace('option_set_', '', $option_set_id);
+    if ($option_set = personalize_option_set_load($osid)) {
+      // Keep track of which explicit targeting features have already been
+      // designated as each can only be specified for one option.
+      // Keep track of feature strings that have already been designated to options,
+      // which options they have been designated to, and whether there's a rule
+      // associated with each feature.
+      $designated_features = $targeting = array();
+      $target_weight = 0;
+      if (empty($values['options'])) {
+        continue;
+      }
+      foreach ($values['options'] as $option_id => $settings) {
+        $feature_values = $rules = array();
+        if (isset($settings['explicit_targeting']) && !empty($settings['explicit_targeting']['mapping'])) {
+          foreach ($settings['explicit_targeting']['mapping']['contexts'] as $delta => $context_values) {
+            if ($context_values['context'] == '') {
+              continue;
+            }
+            list($plugin_name, $context_name) = explode(PERSONALIZE_TARGETING_ADMIN_SEPARATOR, $context_values['context']);
+            $context_values['match'] = $context_values['value']['match'];
+            $context_values['operator'] = $context_values['value']['operator'];
+            unset($context_values['value'], $context_values['remove']);
+            // Generate a value code based on the operator used.
+            $value = personalize_targeting_generate_value_code($context_values['match'], $context_values['operator']);
+            // Create a feature string for this context value that can be consumed
+            // by the agent that will be using it.
+            $feature_string = $agent_instance->convertContextToFeatureString($context_name, $value);
+            $feature_values[] = $feature_string;
+            // Save the actual rule information as this is what will be used
+            // for evaluating it.
+            $rules[$feature_string] = $context_values;
+            // Override the context to split it into plugin and context parts.
+            $rules[$feature_string]['context'] = $context_name;
+            $rules[$feature_string]['plugin'] = $plugin_name;
+          }
+          foreach ($feature_values as $feature) {
+            // Mark this feature string as already designated.
+            if (!in_array($feature, $designated_features)) {
+              $designated_features[] = $feature;
+            }
+            else {
+              drupal_set_message(t('You have set the same targeting feature for more than one option. Depending on whether features are AND\'d or OR\'d together for the different options, and on how the decision agent evaluates explicit targeting rules, this may not produce the desired effect.'), 'warning');
+            }
+          }
+          if (!empty($feature_values)) {
+            $rule = array(
+              'option_id' => $option_id,
+              'targeting_features' => $feature_values,
+              'targeting_rules' => $rules,
+              'weight' => $target_weight,
+            );
+            // If a strategy has been specified for how to use the targeting features,
+            // then store this as well.
+            if (isset($values['options'][$option_id]['explicit_targeting']['strategy'])) {
+              $rule['targeting_strategy'] = $values['options'][$option_id]['explicit_targeting']['strategy'];
+            }
+            $targeting['target_' . ($target_weight + 1)] = $rule;
+            $target_weight++;
+          }
+        }
+      }
+
+      $option_set->targeting = $targeting;
+      personalize_option_set_save($option_set);
+    }
+  }
 }
 
 /**

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -586,51 +586,61 @@ function personalize_campaign_wizard_variations($form, &$form_state, $agent_data
         );
         break;
     }
+    // Add the advanced options.
+    $section['option_set_' . $option_set->osid]['advanced'] = personalize_campaign_wizard_variations_advanced($form, $form_state, $option_set);
+  } // End loop through option sets.
+  return $form;
+}
 
-    // Advanced area per option set.
-    $section['option_set_' . $option_set->osid]['advanced'] = array(
-      '#type' => 'fieldset',
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
-      '#title' => t('Advanced'),
+/**
+ * Helper subform for the advanced section of an option set.
+ */
+function personalize_campaign_wizard_variations_advanced(&$form, &$form_state, $option_set) {
+  $option_set_plugin = personalize_get_option_set_type($option_set->plugin);
+  $advanced = array(
+    '#type' => 'fieldset',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#title' => t('Advanced'),
+  );
+  $advanced['label'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Name',
+    '#description' => 'Shown in the menu when you are viewing content variations on a page.',
+    '#default_value' => isset($option_set->label) ? $option_set->label : '',
+  );
+  $advanced['decision_name'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Decision Name',
+    '#description' => 'By default, this decision will be named after the content variation ID. You can use this if you want to make one conceptual decision across multiple content variations such as a special offer which manifests in different places on the site.',
+    '#default_value' => isset($option_set->decision_name) ? $option_set->decision_name : '',
+  );
+  $advanced['stateful'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Shareable'),
+    '#description' => 'Will display what the original visitor saw, not another variation.',
+    '#default_value' => isset($option_set->stateful) ? $option_set->stateful : 0,
+  );
+  $advanced['preview_link'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Preview link',
+    '#description' => t('Enter the internal Drupal path on your site to a page containing this content variation set. Enter &lt;front&gt; to link to the front page.'),
+    '#default_value' => !empty($option_set->preview_link) ? $option_set->preview_link : '',
+  );
+  // Display options to select the executor if supported.
+  $executors = personalize_get_executors();
+  $supported_executors = module_invoke($option_set_plugin['module'], 'personalize_get_executor_options');
+  if (count($supported_executors) == 1) {
+    $advanced['executor'] = array(
+      '#type' => 'value',
+      '#value' => array_shift(array_keys($supported_executors)),
     );
-    $section['option_set_' . $option_set->osid]['advanced']['label'] = array(
-      '#type' => 'textfield',
-      '#title' => 'Name',
-      '#description' => 'Shown in the menu when you are viewing content variations on a page.',
-      '#default_value' => isset($option_set->label) ? $option_set->label : '',
-    );
-    $section['option_set_' . $option_set->osid]['advanced']['decision_name'] = array(
-      '#type' => 'textfield',
-      '#title' => 'Decision Name',
-      '#description' => 'By default, this decision will be named after the content variation ID. You can use this if you want to make one conceptual decision across multiple content variations such as a special offer which manifests in different places on the site.',
-      '#default_value' => isset($option_set->decision_name) ? $option_set->decision_name : '',
-    );
-    $section['option_set_' . $option_set->osid]['advanced']['stateful'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Shareable'),
-      '#description' => 'Will display what the original visitor saw, not another variation.',
-      '#default_value' => isset($option_set->stateful) ? $option_set->stateful : 0,
-    );
-    $section['option_set_' . $option_set->osid]['advanced']['preview_link'] = array(
-      '#type' => 'textfield',
-      '#title' => 'Preview link',
-      '#description' => t('Enter the internal Drupal path on your site to a page containing this content variation set. Enter &lt;front&gt; to link to the front page.'),
-      '#default_value' => !empty($option_set->preview_link) ? $option_set->preview_link : '',
-    );
-    // Display options to select the executor if supported.
-    $executors = personalize_get_executors();
-    $supported_executors = module_invoke($option_set_plugin['module'], 'personalize_get_executor_options');
-    if (count($supported_executors) == 1) {
-      $section['option_set_' . $option_set->osid]['advanced']['executor'] = array(
-        '#type' => 'value',
-        '#value' => array_shift(array_keys($supported_executors)),
-      );
-    }
-    else if (count($supported_executors) > 1) {
+  }
+  else {
+    if (count($supported_executors) > 1) {
       $default_executor = '';
       $options = array();
-      foreach($supported_executors as $executor_name => &$supported_options) {
+      foreach ($supported_executors as $executor_name => &$supported_options) {
         // Allow the supported declarations to overwrite the default displays.
         $supported_options += $executors[$executor_name];
         $options[$executor_name] = $supported_options['title'];
@@ -647,7 +657,7 @@ function personalize_campaign_wizard_variations($form, &$form_state, $agent_data
         $default_executor = key($supported_executors);
       }
 
-      $section['option_set_' . $option_set->osid]['advanced']['executor'] = array(
+      $advanced['executor'] = array(
         '#type' => 'radios',
         '#title' => t('Rendering'),
         '#options' => $options,
@@ -655,14 +665,14 @@ function personalize_campaign_wizard_variations($form, &$form_state, $agent_data
         '#title_display' => 'invisible',
       );
       // Add descriptions to the executor options
-      foreach($supported_executors as $executor_name => $options) {
-        $section['option_set_' . $option_set -> osid]['advanced']['executor'][$executor_name] = array(
+      foreach ($supported_executors as $executor_name => $options) {
+        $advanced['executor'][$executor_name] = array(
           '#description' => $options['description'] . theme('personalize_admin_info_details', $options),
         );
       }
     }
-  } // End loop through option sets.
-  return $form;
+  }
+  return $advanced;
 }
 
 /**
@@ -1099,8 +1109,8 @@ function personalize_campaign_wizard_validate_variations($form, &$form_state) {
   }
 
   $need_form_state_cache_clear = FALSE;
-
   foreach ($form_values as $option_set_id => $values) {
+    personalize_campaign_wizard_validate_variations_advanced($form_values[$option_set_id], 'option_sets][' . $option_set_id . ']');
     if (!empty($form_values[$option_set_id]['advanced']['preview_link'])) {
       if ($form_values[$option_set_id]['advanced']['preview_link'] != '<front>' && drupal_lookup_path('source', $form_values[$option_set_id]['advanced']['preview_link']) === FALSE) {
         form_set_error('option_sets][' . $option_set_id . '][advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
@@ -1121,6 +1131,25 @@ function personalize_campaign_wizard_validate_variations($form, &$form_state) {
   // Drupal caches form_state before validators are triggered, so flush it
   if ($need_form_state_cache_clear) {
     cache_clear_all('form_state_' . $form_state['values']['form_build_id'], 'cache_form');
+  }
+}
+
+/**
+ * Validation for advanced settings form for a particular option set.
+ *
+ * @param array $form_values
+ *   An array of form state values for each option set.
+ * @param string $parents
+ *   The string representation of the parents to the form values used to target
+ *   error messages, e.g. variations][option_sets][option_set_1]
+ */
+function personalize_campaign_wizard_validate_variations_advanced($form_values, $parents) {
+  if (!empty($form_values['advanced']['preview_link'])) {
+    if ($form_values['advanced']['preview_link'] != '<front>' && drupal_lookup_path('source', $form_values['advanced']['preview_link']) === FALSE) {
+      form_set_error($parents . '[advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
+        '@option_set' => $form_values['advanced']['label'],
+      )));
+    }
   }
 }
 
@@ -1186,16 +1215,9 @@ function personalize_campaign_wizard_submit($form, &$form_state) {
     drupal_set_message(t('There was a problem saving the campaign.'));
   }
 
-  // If the button that caused the submit is from the navigation, then the next
-  // step should be the clicked navigation button regardless of the last step.
-  if ($form_state['triggering_element']['#name'] !== 'wizard_submit') {
-    $form_state['new_step'] = $form_state['triggering_element']['#name'];
-  }
-  else {
-    // If the "Start" button was pressed then start the campaign.
-    if ($form_state['triggering_element']['#value'] === t('Start')) {
-      personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_RUNNING);
-    }
+  // If the "Start" button was pressed then start the campaign.
+  if ($form_state['triggering_element']['#value'] === t('Start')) {
+    personalize_agent_set_status($agent->machine_name, PERSONALIZE_STATUS_RUNNING);
   }
 
   // Rebuild the form to show the next step.
@@ -1248,6 +1270,7 @@ function personalize_campaign_wizard_submit_variations($form, &$form_state, &$ag
       if (isset($values['winner'])) {
         $option_set->winner = $values['winner'];
       }
+      personalize_campaign_wizard_submit_variations_advanced($values, $option_set);
       if (!isset($values['options'])) {
         personalize_option_set_save($option_set);
         continue;
@@ -1315,6 +1338,30 @@ function personalize_campaign_wizard_submit_variations($form, &$form_state, &$ag
     }
   }
   $form_state['new_step'] = 'targeting';
+}
+
+/**
+ * Submit helper for advanced settings within the variations subform.
+ *
+ * Update any advanced options on the option set.
+ *
+ * @param array $form_values
+ *   The form state values that include the "advanced" subform.
+ * @param stdClass $option_set
+ *   The option set class to get the new values.
+ */
+function personalize_campaign_wizard_submit_variations_advanced($form_values, &$option_set) {
+  $option_set->label = $form_values['advanced']['label'];
+  $option_set->stateful = $form_values['advanced']['stateful'];
+  if (isset($form_values['advanced']['executor'])) {
+    $option_set->executor = $form_values['advanced']['executor'];
+  }
+  if (isset($form_values['advanced']['decision_name'])) {
+    $option_set->decision_name = personalize_generate_machine_name($form_values['advanced']['decision_name']);
+  }
+  if (isset($form_values['advanced']['preview_link'])) {
+    $option_set->preview_link = $form_values['advanced']['preview_link'];
+  }
 }
 
 /**

--- a/personalize.admin.campaign.inc
+++ b/personalize.admin.campaign.inc
@@ -626,6 +626,8 @@ function personalize_campaign_wizard_variations_advanced(&$form, &$form_state, $
     '#title' => 'Preview link',
     '#description' => t('Enter the internal Drupal path on your site to a page containing this content variation set. Enter &lt;front&gt; to link to the front page.'),
     '#default_value' => !empty($option_set->preview_link) ? $option_set->preview_link : '',
+    '#element_validate' => array('personalize_form_element_path_validate'),
+    '#allow_external' => FALSE,
   );
   // Display options to select the executor if supported.
   $executors = personalize_get_executors();
@@ -1110,14 +1112,6 @@ function personalize_campaign_wizard_validate_variations($form, &$form_state) {
 
   $need_form_state_cache_clear = FALSE;
   foreach ($form_values as $option_set_id => $values) {
-    personalize_campaign_wizard_validate_variations_advanced($form_values[$option_set_id], 'option_sets][' . $option_set_id . ']');
-    if (!empty($form_values[$option_set_id]['advanced']['preview_link'])) {
-      if ($form_values[$option_set_id]['advanced']['preview_link'] != '<front>' && drupal_lookup_path('source', $form_values[$option_set_id]['advanced']['preview_link']) === FALSE) {
-        form_set_error('option_sets][' . $option_set_id . '][advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
-          '@option_set' => $form_values[$option_set_id]['advanced']['label'],
-        )));
-      }
-    }
     if (!empty($form_values[$option_set_id]['options'])) {
       foreach ($form_values[$option_set_id]['options'] as $option_name => $option) {
         if (isset($option['enable_explicit_targeting']) && $option['enable_explicit_targeting'] == 0) {
@@ -1131,25 +1125,6 @@ function personalize_campaign_wizard_validate_variations($form, &$form_state) {
   // Drupal caches form_state before validators are triggered, so flush it
   if ($need_form_state_cache_clear) {
     cache_clear_all('form_state_' . $form_state['values']['form_build_id'], 'cache_form');
-  }
-}
-
-/**
- * Validation for advanced settings form for a particular option set.
- *
- * @param array $form_values
- *   An array of form state values for each option set.
- * @param string $parents
- *   The string representation of the parents to the form values used to target
- *   error messages, e.g. variations][option_sets][option_set_1]
- */
-function personalize_campaign_wizard_validate_variations_advanced($form_values, $parents) {
-  if (!empty($form_values['advanced']['preview_link'])) {
-    if ($form_values['advanced']['preview_link'] != '<front>' && drupal_lookup_path('source', $form_values['advanced']['preview_link']) === FALSE) {
-      form_set_error($parents . '[advanced][preview_link', t('The preview link for "@option_set" must be a valid internal Drupal path.', array(
-        '@option_set' => $form_values['advanced']['label'],
-      )));
-    }
   }
 }
 

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1324,7 +1324,7 @@ function personalize_explicit_targeting_mapping_element($mapping, $targeting_val
   );
   $element['value'] = array(
     '#tree' => TRUE,
-    '#prefix' => '<div id="' . $wrapper_id. '">',
+    '#prefix' => '<div id="' . $wrapper_id. '" class="personalize-target-value">',
     '#suffix' => '</div>'
   );
   $value_type = isset($value_types[$selected_plugin_context]) ? $value_types[$selected_plugin_context] : 'string';

--- a/personalize.admin.inc
+++ b/personalize.admin.inc
@@ -1089,28 +1089,6 @@ function personalize_targeting_support_form_elements($option_set, $option, $targ
     '#states' => $states,
   );
 
-  $context_options = array('' => '-- ' . t('Select a context') . ' --');
-  $value_types = array();
-  $operator_options = array(
-    'string' => array(
-      'equals' => t('equals'),
-      'contains' => t('contains'),
-      'starts' => t('starts with'),
-      'ends' => t('ends with')
-    ),
-    'number' => array(
-      'equals' => t('equals'),
-      'numgt' => t('greater than'),
-      'numlt' => t('less than')
-    )
-  );
-  foreach ($targeting_values as  $key => $info) {
-    $option_key = $info['visitor_context'] . PERSONALIZE_TARGETING_ADMIN_SEPARATOR . $key;
-    $key_label = isset($info['friendly name']) ? $info['friendly name'] : $key;
-    $context_options[$option_key] = $key_label;
-    $value_types[$option_key] = $info['value type'];
-  }
-
   // This is the portion of the form that will be replace when the "add new" or "remove
   // context" links are clicked.
   $main_wrapper_id = 'personalize-targeting-osid-' . $osid . '-' . $option['option_id'];
@@ -1190,79 +1168,8 @@ function personalize_targeting_support_form_elements($option_set, $option, $targ
 
   $form_state['num_contexts']['option_set_' . $osid][$option['option_id']] = count($mappings);
   foreach ($mappings as $delta => $mapping) {
-    $wrapper_id = 'operator-dropdown-replace-' . $osid . '-' . $option['option_id'] . '-' . $delta;
-    $selected_plugin_context = $mapping['plugin'] . PERSONALIZE_TARGETING_ADMIN_SEPARATOR . $mapping['context'];
-    $selected_context = $mapping['context'];
-    $selected_operator = $mapping['operator'];
-    $selected_match = $mapping['match'];
-    $form['mapping']['contexts'][$delta] = array(
-      '#prefix' => '<div class="personalize-target-wrapper">',
-      '#suffix' => '</div>',
-      'context' => array(
-        '#type' => 'select',
-        '#title' => t('Context'),
-        '#options' => $context_options,
-        '#default_value' => empty($selected_plugin_context) ? '' : $selected_plugin_context,
-        '#ajax' => array(
-          'event' => 'change',
-          'callback' => 'personalize_explicit_targeting_context_callback',
-          'wrapper' => $wrapper_id,
-        ),
-        '#attributes' => array(
-          'class' => array('personalize-targeting-context'),
-        ),
-      ),
-    );
-    $form['mapping']['contexts'][$delta]['value'] = array(
-      '#tree' => TRUE,
-      '#prefix' => '<div id="' . $wrapper_id. '">',
-      '#suffix' => '</div>'
-    );
-    $value_type = isset($value_types[$selected_plugin_context]) ? $value_types[$selected_plugin_context] : 'string';
-    // We use different form elements depending on whether there is a predefined list
-    // of possible values or not.
-    switch ($value_type) {
-      case 'predefined':
-        $form['mapping']['contexts'][$delta]['value']['operator'] = array(
-          '#type' => 'value',
-          '#value' => 'equals',
-        );
-        $form['mapping']['contexts'][$delta]['value']['match'] = array(
-          '#type' => 'select',
-          '#options' => $targeting_values[$selected_context]['values'],
-          '#title' => 'Value',
-          '#default_value' => $selected_match,
-        );
-       break;
-      case 'boolean':
-        $form['mapping']['contexts'][$delta]['value']['operator'] = array(
-          '#type' => 'value',
-          '#value' => 'equals',
-        );
-        $off_label = isset($targeting_values[$selected_context]['off_label']) ? $targeting_values[$selected_context]['off_label'] : 'No';
-        $on_label = isset($targeting_values[$selected_context]['on_label']) ? $targeting_values[$selected_context]['on_label'] : 'Yes';
-        $form['mapping']['contexts'][$delta]['value']['match'] = array(
-          '#type' => 'select',
-          '#options' => array(0 => $off_label, 1 => $on_label),
-          '#title' => 'Value',
-          '#default_value' => $selected_match,
-        );
-        break;
-      default:
-        $form['mapping']['contexts'][$delta]['value']['operator'] = array(
-          '#type' => 'select',
-          '#title' => t('Operator'),
-          '#options' => $operator_options[$value_type],
-          '#default_value' => $selected_operator
-        );
-        $form['mapping']['contexts'][$delta]['value']['match'] = array(
-          '#type' => 'textfield',
-          '#title' => 'Value',
-          '#size' => $value_type == 'number' ? 6 : 30,
-          '#default_value' => $selected_match,
-        );
-        break;
-    }
+    $wrapper_id =  $osid . '-' . $option['option_id'] . '-' . $delta;
+    $form['mapping']['contexts'][$delta] = personalize_explicit_targeting_mapping_element($mapping, $targeting_values, $wrapper_id);
 
     // Add a "remove" button for this context.
     // NOTE: ajax.js expects the ID of the element to match the element's name
@@ -1350,6 +1257,122 @@ function personalize_targeting_support_form_elements($option_set, $option, $targ
     );
   }
   return $form;
+}
+
+/**
+ * Helper function to generate an element for the selection of context to apply
+ * to a rule.
+ *
+ * @param array $mapping
+ *   The mapping for the context plugin and values to match.  Mapping contains:
+ *   - plugin: the context plugin responsible for providing this data.
+ *   - context: the specific context to match
+ *   - operator: the operator that defines the type of match
+ *   - match: the value to match (if appropriate to the operator)
+ * @param array $targeting_values
+ *   The available context values.
+ * @param string $wrapper_id
+ *   A unique id that can be used within this element for AJAX purposes.
+ */
+function personalize_explicit_targeting_mapping_element($mapping, $targeting_values, $wrapper_id) {
+  // @todo Cache the context options, value types, and operator options as this
+  // function can be called multiple times per form.
+  $context_options = array('' => '-- ' . t('Select a context') . ' --');
+  $value_types = array();
+  foreach ($targeting_values as  $key => $info) {
+    $option_key = $info['visitor_context'] . PERSONALIZE_TARGETING_ADMIN_SEPARATOR . $key;
+    $key_label = isset($info['friendly name']) ? $info['friendly name'] : $key;
+    $context_options[$option_key] = $key_label;
+    $value_types[$option_key] = $info['value type'];
+  }
+
+  $wrapper_id = 'operator-dropdown-replace-' . $wrapper_id;
+  $selected_plugin_context = $mapping['plugin'] . PERSONALIZE_TARGETING_ADMIN_SEPARATOR . $mapping['context'];
+  $selected_context = $mapping['context'];
+  $selected_operator = $mapping['operator'];
+  $selected_match = $mapping['match'];
+  $operator_options = array(
+    'string' => array(
+      'equals' => t('equals'),
+      'contains' => t('contains'),
+      'starts' => t('starts with'),
+      'ends' => t('ends with')
+    ),
+    'number' => array(
+      'equals' => t('equals'),
+      'numgt' => t('greater than'),
+      'numlt' => t('less than')
+    )
+  );
+  $element = array(
+    '#prefix' => '<div class="personalize-target-wrapper">',
+    '#suffix' => '</div>',
+    'context' => array(
+      '#type' => 'select',
+      '#title' => t('Context'),
+      '#options' => $context_options,
+      '#default_value' => empty($selected_plugin_context) ? '' : $selected_plugin_context,
+      '#ajax' => array(
+        'event' => 'change',
+        'callback' => 'personalize_explicit_targeting_context_callback',
+        'wrapper' => $wrapper_id,
+      ),
+      '#attributes' => array(
+        'class' => array('personalize-targeting-context'),
+      ),
+    ),
+  );
+  $element['value'] = array(
+    '#tree' => TRUE,
+    '#prefix' => '<div id="' . $wrapper_id. '">',
+    '#suffix' => '</div>'
+  );
+  $value_type = isset($value_types[$selected_plugin_context]) ? $value_types[$selected_plugin_context] : 'string';
+  // We use different form elements depending on whether there is a predefined list
+  // of possible values or not.
+  switch ($value_type) {
+    case 'predefined':
+      $element['value']['operator'] = array(
+        '#type' => 'value',
+        '#value' => 'equals',
+      );
+      $element['value']['match'] = array(
+        '#type' => 'select',
+        '#options' => $targeting_values[$selected_context]['values'],
+        '#title' => 'Value',
+        '#default_value' => $selected_match,
+      );
+      break;
+    case 'boolean':
+      $element['value']['operator'] = array(
+        '#type' => 'value',
+        '#value' => 'equals',
+      );
+      $off_label = isset($targeting_values[$selected_context]['off_label']) ? $targeting_values[$selected_context]['off_label'] : 'No';
+      $on_label = isset($targeting_values[$selected_context]['on_label']) ? $targeting_values[$selected_context]['on_label'] : 'Yes';
+      $element['value']['match'] = array(
+        '#type' => 'select',
+        '#options' => array(0 => $off_label, 1 => $on_label),
+        '#title' => 'Value',
+        '#default_value' => $selected_match,
+      );
+      break;
+    default:
+      $element['value']['operator'] = array(
+        '#type' => 'select',
+        '#title' => t('Operator'),
+        '#options' => $operator_options[$value_type],
+        '#default_value' => $selected_operator
+      );
+      $element['value']['match'] = array(
+        '#type' => 'textfield',
+        '#title' => 'Value',
+        '#size' => $value_type == 'number' ? 6 : 30,
+        '#default_value' => $selected_match,
+      );
+      break;
+  }
+  return $element;
 }
 
 /**

--- a/personalize.module
+++ b/personalize.module
@@ -3040,7 +3040,9 @@ function _personalize_convert_option_set_to_js_setting($option_set) {
     if (isset($option_set->winner) && $option_set->winner == $option['option_id']) {
       $os_array['winner'] = $i;
     }
-    $os_array['options'][$i]['option_label'] = filter_xss($option['option_label']);
+    if (isset($option['option_label'])) {
+      $os_array['options'][$i]['option_label'] = filter_xss($option['option_label']);
+    }
   }
   $os_array['option_names'] = $option_names;
   $os_array += array(

--- a/personalize.module
+++ b/personalize.module
@@ -3182,3 +3182,66 @@ function _personalize_is_action_used($action_name) {
 
   return $query->count()->execute() > 0;
 }
+
+/**
+ * An element level validator to validate that a path is valid and that the user
+ * has access to the path.
+ *
+ * @param array $element
+ *   The form element to check.  The form element may optionally include:
+ *   - #allow_external:  Boolean to indicate if external urls are allowed
+ *     (defaults to TRUE).
+ *   - #allow_dynamic: Boolean indicating if wildcard characters are allowed
+ *     for dynamic urls (defaults to FALSE).
+ * @param array $form_state
+ *   The current form state.
+ */
+function personalize_form_element_path_validate($element, &$form_state) {
+  $value = $element['#value'];
+  if (empty($value)) {
+    return;
+  }
+  // Set defaults.
+  $element['#allow_external'] = isset($element['#allow_external']) ? $element['#allow_external'] : TRUE;
+  $element['#allow_dynamic'] = isset($element['#allow_dynamic']) ? $element['#allow_dynamic'] : FALSE;
+
+  // Get an array of paths to validate.
+  $validate = array();
+  if ($element['#type'] === 'textarea') {
+    foreach (preg_split('~[\r\n]+~', $value) as $line) {
+      if (empty($line)) {
+        continue;
+      }
+      $validate[] = $line;
+    }
+  }
+  else {
+    $validate[] = $value;
+  }
+  // Check each line and stop after adding an error message to avoid duplicate
+  // processing and messaging.
+  foreach ($validate as $path) {
+    if ($path === '<front>') {
+      continue;
+    }
+    // Check for external links.
+    if ($element['#allow_external'] == FALSE && url_is_external($path)) {
+      form_error($element, t('External paths are not allowed for %element', array(
+        '%element' => empty($element['#title']) ? $element['#name'] : $element['#title']
+      )));
+      break;
+    }
+
+    // Check if path is valid.  drupal_valid_path checks for dynamic paths
+    // using % as the wildcard and is broken at that. As a result we test using
+    // the non-dynamic portion.
+    $dynamic = substr($path, -2) === '/*';
+    $test = $dynamic && $element['#allow_dynamic'] ? substr($path, 0, -2) : $path;
+    if (!drupal_valid_path(drupal_get_normal_path($test))) {
+      form_error($element, t('You have specified an invalid path for %element', array(
+        '%element' => empty($element['#title']) ? $element['#name'] : $element['#title']
+      )));
+      break;
+    }
+  }
+}

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1094,7 +1094,7 @@ EOT;
       "option_sets[option_set_$osid2][options][option-A][explicit_targeting][mapping][contexts][0][value][match]" => 'first value',
       "option_sets[option_set_$osid2][options][option-A][explicit_targeting][strategy]" => 'OR',
     );
-    $this->drupalPost("admin/structure/personalize/manage/{$agent->machine_name}/variations", $edit, $this->getButton('wizard_next'));
+    $this->drupalPost("admin/structure/personalize/manage/{$agent->machine_name}/targeting", $edit, $this->getButton('wizard_next'));
 
     // Start the agent up and verify the various contexts are included.
     personalize_agent_set_status($machine_name, PERSONALIZE_STATUS_RUNNING);
@@ -1515,7 +1515,7 @@ class PersonalizeOptionSetTest extends PersonalizeBaseTest {
       "option_sets[option_set_$osid][options][option-A][explicit_targeting][mapping][contexts][0][value][match]" => 'first value',
       "option_sets[option_set_$osid][options][option-A][explicit_targeting][strategy]" => 'OR',
     );
-    $this->drupalPost("admin/structure/personalize/manage/$machine_name/variations", $edit, $this->getButton('wizard_next'));
+    $this->drupalPost("admin/structure/personalize/manage/$machine_name/targeting", $edit, $this->getButton('wizard_next'));
     $this->resetAll();
     $option_set = personalize_option_set_load($osid);
     $target_name = 'target_1';
@@ -1588,7 +1588,7 @@ class PersonalizeOptionSetTest extends PersonalizeBaseTest {
     $osid = $option_set->osid;
 
     // Confirm that we have visitor context options but cannot set fixed targeting.
-    $this->drupalGet("admin/structure/personalize/manage/$machine_name/variations");
+    $this->drupalGet("admin/structure/personalize/manage/$machine_name/targeting");
     $this->assertNoField("option_sets[option_set_$osid][options][option-A][enable_explicit_targeting]");
     $this->assertNoField("option_sets[option_set_$osid][options][option-B][enable_explicit_targeting]");
 
@@ -1604,7 +1604,7 @@ class PersonalizeOptionSetTest extends PersonalizeBaseTest {
       "option_sets[option_set_$osid][options][option-A][explicit_targeting][mapping][contexts][0][value][match]" => 'first value',
       "option_sets[option_set_$osid][options][option-A][explicit_targeting][strategy]" => 'OR',
     );
-    $this->drupalPost("admin/structure/personalize/manage/$machine_name/variations", $edit, $this->getButton('wizard_next'));
+    $this->drupalPost("admin/structure/personalize/manage/$machine_name/targeting", $edit, $this->getButton('wizard_next'));
     $this->resetAll();
     $option_set = personalize_option_set_load($osid);
     $target_name = 'target_1';

--- a/tests/personalize.test
+++ b/tests/personalize.test
@@ -1451,14 +1451,14 @@ class PersonalizeOptionSetTest extends PersonalizeBaseTest {
       'option_sets[option_set_1][advanced][preview_link]' => 'http://google.com',
     );
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
-    $this->assertText(t('The preview link for "Option Set 1" must be a valid internal Drupal path.'));
+    $this->assertText(t('External paths are not allowed for Preview link'));
 
     // Try adding a link to a page that does not exist.
     $edit = array(
       'option_sets[option_set_1][advanced][preview_link]' => 'node/' . $this->randomString(),
     );
     $this->drupalPost(NULL, $edit, $this->getButton('wizard_next'));
-    $this->assertText(t('The preview link for "Option Set 1" must be a valid internal Drupal path.'));
+    $this->assertText(t('You have specified an invalid path for Preview link'));
 
     // Add a good preview link and verify that preview links are added.
     $edit = array(


### PR DESCRIPTION
Moves targeting from the "What" form to the "Who" form.
Centralizes the step processing rather than specifying the order in multiple places.
Ensures that only agents that should have access can access the "Who" or "Why" subforms.
Add the general "Save" button to the process bar.
