### PR TITLE
Ch 2470: Don't allow targeted variations to be removed from running campaigns

### DIFF
--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -66,9 +66,6 @@ function personalize_blocks_form($form, &$form_state, $formtype, $pblock = NULL)
   }
 
   if (!empty($pblock->osid)) {
-    // Make sure a warning message is delivered if this is a running
-    // campaign.
-    personalize_warn_if_running($pblock->agent);
     $form['osid'] = array(
       '#type' => 'value',
       '#value' => $pblock->osid,

--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -530,6 +530,41 @@ function personalize_blocks_block_delete_submit($form, &$form_state) {
   $form_state['redirect'] = 'admin/structure/personalize/variations/personalize-blocks';
 }
 
+/**
+ * Deletion of personalized_block block option from within an existing
+ * personalized block.
+ */
+function personalize_blocks_block_option_delete($form, $form_state, $pblock, $option_id) {
+  $option_label = $option_id;
+  foreach($pblock->options as $option) {
+    if ($option['option_id'] === $option_id) {
+      $option_label = $option['option_label'];
+      break;
+    }
+  }
+  $form['osid'] = array('#type' => 'hidden', '#value' => $pblock->osid);
+  $form['option_id'] = array('#type' => 'hidden', '#value' => $option_id);
+  $form['block_title'] = array('#type' => 'hidden', '#value' => $pblock->data['block_title']);
+  $form['option_label'] = array('#type' => 'hidden', '#value' => $option_label);
+  return confirm_form($form, t('Are you sure you want to delete variation %option_label from the %title personalized block?', array('%option_label' => $option_label, '%title' => $pblock->data['block_title'])), 'admin/structure/personalize/variations/personalize-blocks/manage/' . $pblock->osid, '', t('Delete'), t('Cancel'));
+}
+
+/**
+ * Submit handler for personalized_block block deletion.
+ */
+function personalize_blocks_block_option_delete_submit($form, &$form_state) {
+  $option_set = personalize_option_set_load($form_state['values']['osid']);
+  foreach($option_set->options as $i => $option) {
+    if ($option['option_id'] === $form_state['values']['option_id']) {
+      unset($option_set->options[$i]);
+      break;
+    }
+  }
+  personalize_option_set_save($option_set);
+  drupal_set_message(t('The variation %option_label has been removed from the %block_title personalized block.', array('%option_label' => $form_state['values']['option_label'], '%block_title' => $form_state['values']['block_title'])));
+  cache_clear_all();
+  $form_state['redirect'] = 'admin/structure/personalize/variations/personalize-blocks';
+}
 
 /**
  * Helper function to get all blocks.

--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -419,6 +419,10 @@ function theme_personalize_blocks_admin_form_draggable_blocks($variables) {
  * Ajax callback for the add tab and remove tab buttons.
  */
 function personalize_blocks_ajax_callback($form, $form_state) {
+  // Clear messages since they don't need to be repeated within the AJAX
+  // callback area.
+  drupal_get_messages();
+
   return $form['pblock_wrapper']['blocks'];
 }
 

--- a/modules/personalize_blocks/personalize_blocks.admin.inc
+++ b/modules/personalize_blocks/personalize_blocks.admin.inc
@@ -331,6 +331,7 @@ function _personalize_blocks_add_block_form(&$form_state) {
  * @ingroup themeable
  */
 function theme_personalize_blocks_admin_form_blocks($variables) {
+  $has_operations = FALSE;
   $blocks = $variables['blocks'];
   $draggable = isset($blocks['#draggable']) && $blocks['#draggable'];
   $rows = array();
@@ -359,6 +360,11 @@ function theme_personalize_blocks_admin_form_blocks($variables) {
     if ($draggable) {
       $fields[] = array('data' => drupal_render($block['weight']), 'class' => array('personalized-blocks-weight'));
     }
+
+    if (!isset($block['remove']['#access']) || $block['remove']['#access'] === TRUE) {
+      $has_operations = TRUE;
+    }
+
     $fields = array_merge($fields, array(
       array('data' => drupal_render($block['block']), 'class' => array('personalized-block-block')),
       array('data' => drupal_render($block['remove']), 'class' => array('personalize-block-remove'))
@@ -375,6 +381,14 @@ function theme_personalize_blocks_admin_form_blocks($variables) {
       $row = array_merge($row, $block['#attributes']);
     }
     $rows[] = $row;
+  }
+
+  // If there were never any operations available then remove the column.
+  if (!$has_operations) {
+    array_pop($header);
+    foreach ($rows as &$row) {
+      array_pop($row['data']);
+    }
   }
 
   $build['personalized_block'] = array(

--- a/modules/personalize_blocks/personalize_blocks.module
+++ b/modules/personalize_blocks/personalize_blocks.module
@@ -45,6 +45,14 @@ function personalize_blocks_menu() {
     'type' => MENU_LOCAL_TASK,
     'file' => 'personalize_blocks.admin.inc',
   );
+  $items['admin/structure/personalize/variations/personalize-blocks/manage/%personalize_block/%/delete'] = array(
+    'title' => 'Delete Personalized Block Variation',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('personalize_blocks_block_option_delete', 6, 7),
+    'access arguments' => array('manage personalized content'),
+    'type' => MENU_CALLBACK,
+    'file' => 'personalize_blocks.admin.inc',
+  );
   $items['admin/structure/personalize/variations/personalize-blocks/manage/%personalize_block/clone'] = array(
     'title' => 'Clone Personalized Block',
     'page callback' => 'personalize_blocks_clone',

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -88,9 +88,6 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
     }
   }
   if (!empty($option_set->osid)) {
-    // Make sure a warning message is delivered if this is a running
-    // campaign.
-    personalize_warn_if_running($option_set->agent);
     $form['osid'] = array(
       '#type' => 'value',
       '#value' => $option_set->osid,

--- a/modules/personalize_elements/personalize_elements.admin.inc
+++ b/modules/personalize_elements/personalize_elements.admin.inc
@@ -84,7 +84,11 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
   }
   elseif (isset($option_set->options)) {
     foreach ($option_set->options as $option) {
-      $options[] = array('option_label' => $option['option_label'], 'personalize_elements_content' => isset($option['personalize_elements_content']) ? $option['personalize_elements_content'] : '');
+      $options[] = array(
+        'option_id' => $option['option_id'],
+        'option_label' => $option['option_label'],
+        'personalize_elements_content' => isset($option['personalize_elements_content']) ? $option['personalize_elements_content'] : ''
+      );
     }
   }
   if (!empty($option_set->osid)) {
@@ -166,6 +170,7 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
       'option_label' => personalize_generate_option_label($index),
       'content' => '',
       'is_new' => TRUE,
+      'option_id' => '',
     );
   }
   $show_control = TRUE;
@@ -186,6 +191,7 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
     array_unshift($options, array(
       'option_label' => PERSONALIZE_CONTROL_OPTION_LABEL,
       'personalize_elements_content' => '',
+      'option_id' => PERSONALIZE_CONTROL_OPTION_ID,
     ));
   }
   $form_state['num_options'] = count($options);
@@ -230,6 +236,10 @@ function personalize_elements_form($form, &$form_state, $isAjax = FALSE, $option
     $option_form = array(
       '#tree' => TRUE,
       '#type' => 'container',
+    );
+    $option_form['option_id'] = array(
+      '#type' => 'value',
+      '#value' => $option['option_id'],
     );
     $option_form['option_label'] = array(
       '#prefix' => '<div class="personalize-elements-option-label-element">',

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -309,7 +309,6 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
 
     // Load the Option Sets if we have an entity id and entity.
     if ($entity_id && ($option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key))) {
-      personalize_warn_if_running($option_set->agent);
       // Add the content variation field data for each option.
       foreach ($option_set->options as $option) {
         if (isset($limit_option_ids) && !in_array($option['option_id'], $limit_option_ids)) {

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -1185,20 +1185,37 @@ function _personalize_fields_get_cid_for_field($entity_type, $entity_id, $field_
  * TRUE, then this will return TRUE even if the value is an empty value.
  */
 function _personalize_fields_option_has_value($option, $empty = FALSE) {
+  $option_value = personalize_fields_get_option_value($option);
+  return !empty($option_value) || $empty;
+}
+
+/**
+ * Helper function to retrieve the value portion from a personalize field.
+ *
+ * @param $option
+ *   The option array representing the field.  This can be either the form
+ *   render array or the form state values.
+ * @param mixed
+ *   If a form render array is pasesd, then this will be the renderable value
+ *   child.  If a form state values array is passed then this will be the
+ *   actual value.  An empty value could be a 0 for ids, an empty array, or
+ *   an empty string and therefore values should be checked using empty().
+ */
+function personalize_fields_get_option_value($option) {
   if (!is_array($option)) {
-    return FALSE;
+    return array();
   }
   // Supports all fields that use a 'value' column.
   if (array_key_exists('value', $option)) {
-    return !empty($option['value']) || $empty;
+    return $option['value'];
   }
   // Supports file fields.
   if (array_key_exists('fid', $option)) {
-    return (int) $option['fid'] > 0 || $empty;
+    return $option['fid'];
   }
   // Supports entity_reference fields.
   if (array_key_exists('target_id', $option)) {
-    return !empty($option['target_id']) || $empty;
+    return $option['target_id'];
   }
-  return FALSE;
+  return array();
 }

--- a/modules/personalize_fields/personalize_fields.module
+++ b/modules/personalize_fields/personalize_fields.module
@@ -309,6 +309,9 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
 
     // Load the Option Sets if we have an entity id and entity.
     if ($entity_id && ($option_set = _personalize_fields_get_option_set_for_field($entity_type, $entity_id, $key))) {
+      // Add the option set id to the field data.
+      $form[$key]['#attributes']['data-personalize-agent'] = $option_set->agent;
+      $form[$key]['#attributes']['data-personalize-osid'] = $option_set->osid;
       // Add the content variation field data for each option.
       foreach ($option_set->options as $option) {
         if (isset($limit_option_ids) && !in_array($option['option_id'], $limit_option_ids)) {
@@ -348,6 +351,8 @@ function personalize_fields_add_personalized_fields(&$form, &$form_state, $entit
               // This option has been removed from the form.
               continue;
             }
+            $form[$collection_field_name][$collection_field_language][$collection_field_index][$subfield_name]['#attributes']['data-personalize-agent'] = $option_set->agent;
+            $form[$collection_field_name][$collection_field_language][$collection_field_index][$subfield_name]['#attributes']['data-personalize-osid'] = $option_set->osid;
             $form[$collection_field_name][$collection_field_language][$collection_field_index][$subfield_name][$subfield_language][$field_counter] += array('personalize_fields_option_id' => array(
               '#type' => 'value',
               '#value' => $option['option_id'],

--- a/personalize.api.php
+++ b/personalize.api.php
@@ -173,6 +173,18 @@ function hook_personalize_option_set_delete($option_set) {
 }
 
 /**
+ * Allow alteration of the element to be rendered for an option set.
+ *
+ * @param array $element
+ *   The render element by reference.
+ * @param stdClass $option_set
+ *   The option set data.
+ */
+function hook_personalize_option_set_render(&$element, $option_set) {
+
+}
+
+/**
  * Respond to an MVT being deleted.
  *
  * This hook is invoked after an MVT has been deleted from the db.

--- a/personalize.module
+++ b/personalize.module
@@ -1343,42 +1343,6 @@ function personalize_admin_mode() {
 function personalize_debug_mode_enabled() {
   return variable_get('personalize_enable_debug_mode', FALSE);
 }
-/**
- * Sets a warning message if the passed in agent is running.
- *
- * @param $agent_name
- *   The name of the agent.
- */
-function personalize_warn_if_running($agent_name) {
-  $status = personalize_agent_get_status($agent_name);
-  if ($status & PERSONALIZE_STATUS_RUNNING) {
-    drupal_set_message(t('You are editing content in a running personalization, which may affect the integrity of the personalization data. The personalization will be paused if you make changes here.'), 'warning');
-  }
-}
-
-/**
- * Pauses the passed in agent if it's running.
- *
- * @param string $agent_name
- *   The name of the agent.
- */
-function personalize_pause_if_running($agent_name) {
-  $status = personalize_agent_get_status($agent_name);
-  if ($status & PERSONALIZE_STATUS_RUNNING) {
-    personalize_agent_set_status($agent_name, PERSONALIZE_STATUS_PAUSED);
-    $campaign_url = "admin/structure/personalize/manage/{$agent_name}";
-    $current_path = current_path();
-    $destination_path = isset($_GET['destination']) ? $_GET['destination'] : $current_path;
-    if ($current_path !== $campaign_url && $destination_path != $campaign_url) {
-      drupal_set_message(t('The personalization has been paused because you have made changes. You can edit and restart the personalization !here or from the Acquia Lift tool bar.', array('!here' => l('here', $campaign_url))), 'warning');
-    }
-    else {
-      module_load_include('inc', 'personalize', 'personalize.admin');
-      drupal_set_message(t('The personalization has been paused because you have made changes.'));
-      personalize_status_toggle_message($agent_name, PERSONALIZE_STATUS_PAUSED);
-    }
-  }
-}
 
 /**
  * Returns an agent selection form element for use in option set forms.


### PR DESCRIPTION
- Support confirmation form to delete a personalize block option
- Remove unused warn if running logic
- Add supporting information into personalize fields and elements options
- Add helper functions
- Update displays when remove buttons are not available
